### PR TITLE
✨ add paper trade mode

### DIFF
--- a/pyrb/main.py
+++ b/pyrb/main.py
@@ -3,7 +3,7 @@ from typing import Literal, cast
 import click
 import typer
 
-from pyrb.client import brokerage_api_client_factory
+from pyrb.client import TradeMode, brokerage_api_client_factory
 from pyrb.exceptions import InsufficientFundsException
 from pyrb.fetcher import CurrentPrice, PriceFetcher, price_fetcher_factory
 from pyrb.order import Order, OrderType
@@ -44,8 +44,9 @@ def callback() -> None:
 def rebalance(
     investment_amount: float = typer.Option(..., prompt="Enter the total investment amount"),
     brokerage_name: str = typer.Option("ebest", "--brokerage", "-b"),
+    trade_mode: TradeMode = typer.Option(TradeMode.PAPER, "--trade-mode", "-t"),
 ) -> None:
-    context = _create_rebalance_context(brokerage_name)
+    context = _create_rebalance_context(brokerage_name, trade_mode)
     _validate_investment_amount(context, investment_amount)
 
     weight_by_stock = _get_weight_by_stock(context.portfolio)
@@ -65,8 +66,8 @@ def _validate_investment_amount(context: RebalanceContext, investment_amount: fl
         )
 
 
-def _create_rebalance_context(brokerage_name: str) -> RebalanceContext:
-    brokerage_api_client = brokerage_api_client_factory(brokerage_name)
+def _create_rebalance_context(brokerage_name: str, trade_mode: TradeMode) -> RebalanceContext:
+    brokerage_api_client = brokerage_api_client_factory(brokerage_name, trade_mode)
 
     portfolio = portfolio_factory(brokerage_api_client)
     price_fetcher = price_fetcher_factory(brokerage_api_client)


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces a new feature that allows users to switch between real and paper trading modes in the Ebest API client. This is achieved by adding a new `TradeMode` enum and modifying the `EbestAPIClient` and `brokerage_api_client_factory` to accept a `trade_mode` parameter.
> 
> ## What changed
> - A new `TradeMode` enum was added with two options: `REAL` and `PAPER`.
> - The `EbestAPIClient` constructor now accepts a `trade_mode` parameter, which defaults to `TradeMode.PAPER`.
> - The `brokerage_api_client_factory` function now accepts a `trade_mode` parameter.
> - The `appkey` and `appsecretkey` used in the `_issue_access_token` method of `EbestAPIClient` now depend on the `trade_mode`.
> - The `rebalance` function and `_create_rebalance_context` function in `main.py` now accept a `trade_mode` parameter.
> 
> ## How to test
> 1. Pull the changes from this branch into your local environment.
> 2. Run your test suite to ensure no existing functionality is broken.
> 3. Create an instance of `EbestAPIClient` with `TradeMode.REAL` and `TradeMode.PAPER` and ensure the correct `appkey` and `appsecretkey` are used.
> 4. Call the `rebalance` function with different `trade_mode` values and ensure the correct `EbestAPIClient` instance is created.
> 
> ## Why make this change
> This change allows users to easily switch between real and paper trading modes, which is useful for testing and development purposes. It also makes the code more flexible and easier to maintain, as the trading mode can be changed in one place.
</details>