### PR TITLE
📝 add docs for paper trading mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ export EBEST_APP_KEY="your_app_key_here"
 export EBEST_APP_SECRET="your_app_secret_here"
 ```
 
+If you want to use the paper trade mode, set up the environmental variables as follows:
+
+```bash
+export EBEST_PAPER_APP_KEY="your_paper_app_key_here"
+export EBEST_PAPER_APP_SECRET="your_paper_app_secret_here"
+```
+
 Run the tool with:
 
 ```bash


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> # Pull Request Description
> 
> ## TL;DR
> This pull request adds instructions to the README.md file on how to set up environmental variables for paper trade mode.
> 
> ## What changed
> The README.md file was updated with instructions on how to set up environmental variables for paper trade mode. This includes the addition of `EBEST_PAPER_APP_KEY` and `EBEST_PAPER_APP_SECRET`.
> 
> ```diff
> +If you want to use the paper trade mode, set up the environmental variables as follows:
> +
> +```bash
> +export EBEST_PAPER_APP_KEY="your_paper_app_key_here"
> +export EBEST_PAPER_APP_SECRET="your_paper_app_secret_here"
> +```
> ```
> 
> ## How to test
> To test this change, follow the instructions in the updated README.md file to set up the environmental variables for paper trade mode. Then, run the tool and verify that it works as expected in paper trade mode.
> 
> ## Why make this change
> This change was made to provide clear instructions for users who want to use the paper trade mode. This will make it easier for users to get started with the tool and use it in a way that suits their needs.
</details>