### PR TITLE
⚰️ remove click legacy

### DIFF
--- a/pyrb/controller.py
+++ b/pyrb/controller.py
@@ -1,4 +1,3 @@
-import click
 import typer
 
 from pyrb.brokerage.base.client import TradeMode
@@ -30,7 +29,7 @@ def rebalance(
     if user_confirmation:
         rebalancer.place_orders(orders)
     else:
-        click.echo("No orders were placed")
+        typer.echo("No orders were placed")
 
     _report_orders(orders)
 
@@ -38,18 +37,18 @@ def rebalance(
 def _get_confirm_for_order_submit(context: RebalanceContext, orders: list[Order]) -> bool:
     """Confirm orders to the user and return the user's confirmation."""
     for order in orders:
-        click.echo(f"{order.symbol}: {order.side} {order.quantity} shares @ {order.price}")
+        typer.echo(f"{order.symbol}: {order.side} {order.quantity} shares @ {order.price}")
 
-    return click.confirm("Do you want to place these orders?")
+    return typer.confirm("Do you want to place these orders?")
 
 
 def _report_orders(orders: list[Order]) -> None:
     """Provides a summary of successful and failed orders."""
     for order in orders:
         if order.status == OrderStatus.PLACED:
-            click.echo(f"Successfully placed order: {order}")
+            typer.echo(f"Successfully placed order: {order}")
         elif order.status == OrderStatus.REJECTED:
-            click.echo(f"Failed to place order: {order}")
+            typer.echo(f"Failed to place order: {order}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request replaces the usage of the `click` library with the `typer` library in the `pyrb/controller.py` file. 
> 
> ## What changed
> The `click` library was previously used for command-line interaction. This has been replaced with the `typer` library, which is a modern, easy-to-use library for building command-line interfaces. All instances of `click.echo` and `click.confirm` have been replaced with `typer.echo` and `typer.confirm` respectively.
> 
> ## How to test
> To test these changes, run the `pyrb/controller.py` file and observe the command-line interactions. Ensure that the output and confirmations are displayed correctly and that the user can interact with the command-line interface as expected.
> 
> ## Why make this change
> The `typer` library provides a more intuitive and user-friendly interface for command-line interactions. It also supports automatic help generation and command completion, which can improve the user experience. By replacing `click` with `typer`, we can leverage these benefits and enhance the functionality of our command-line interface.
</details>