### PR TITLE
🦺 ease validation

### DIFF
--- a/pyrb/brokerage/base/portfolio.py
+++ b/pyrb/brokerage/base/portfolio.py
@@ -1,6 +1,6 @@
 import abc
 
-from pydantic import BaseModel, PositiveFloat, PositiveInt
+from pydantic import BaseModel, NonNegativeFloat, PositiveFloat, PositiveInt
 
 
 class Position(BaseModel):
@@ -17,12 +17,12 @@ class Portfolio(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def total_value(self) -> PositiveFloat:
+    def total_value(self) -> NonNegativeFloat:
         """Calculates the total value of the portfolio.
         total value = cash + sum of the market value of all positions
 
         Returns:
-            PositiveFloat: The total value of the portfolio.
+            NonNegativeFloat: The total value of the portfolio.
         """
         ...
 

--- a/pyrb/brokerage/ebest/portfolio.py
+++ b/pyrb/brokerage/ebest/portfolio.py
@@ -1,4 +1,4 @@
-from pydantic import PositiveFloat
+from pydantic import NonNegativeFloat
 from requests import Response
 
 from pyrb.brokerage.base.portfolio import Portfolio, Position
@@ -10,7 +10,7 @@ class EbestPortfolio(Portfolio):
         self._api_client = api_client
 
     @property
-    def total_value(self) -> PositiveFloat:
+    def total_value(self) -> NonNegativeFloat:
         response = self._fetch_portfolio()
         res = response.json()
 


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request changes the return type of the `total_value` method in the `Portfolio` class from `PositiveFloat` to `NonNegativeFloat`. This change is reflected in both the base `Portfolio` class and the `EbestPortfolio` class.
> 
> ## What changed
> The `total_value` method in the `Portfolio` class and the `EbestPortfolio` class now returns a `NonNegativeFloat` instead of a `PositiveFloat`. This change is necessary to allow for the possibility of a portfolio having a total value of 0.
> 
> ## How to test
> To test this change, create a portfolio with a total value of 0 and call the `total_value` method. The method should return 0 without any errors. 
> 
> ## Why make this change
> This change is necessary to accurately represent the total value of a portfolio. In the real world, it's possible for a portfolio to have a total value of 0, so our code should be able to handle this scenario. By changing the return type of the `total_value` method to `NonNegativeFloat`, we're allowing for this possibility.
</details>