### PR TITLE
🧑‍💻 add extension settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,6 @@
   "editor.formatOnSave": true,
   "python.languageServer": "Pylance",
   "python.analysis.typeCheckingMode": "off",
-  "python.formatting.provider": "none",
   "python.linting.mypyEnabled": true,
   "python.linting.enabled": true,
   "[python]": {
@@ -11,6 +10,8 @@
       "source.organizeImports": true
     },
   },
+  "black-formatter.importStrategy": "fromEnvironment",
+  "ruff.importStrategy": "fromEnvironment",
   "git.branchProtection": [
     "main"
   ],


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request removes the `python.formatting.provider` setting and adds `black-formatter.importStrategy` and `ruff.importStrategy` settings in the `.vscode/settings.json` file.
> 
> ## What changed
> - Removed the `python.formatting.provider` setting. This means that the Python extension will use its default formatting provider.
> - Added `black-formatter.importStrategy` and `ruff.importStrategy` settings. These settings specify that the import strategies for the Black and Ruff formatters should be taken from the environment.
> 
> ## How to test
> 1. Pull the changes from this pull request.
> 2. Open the project in VS Code.
> 3. Make some changes to a Python file and save it. The changes should be automatically formatted according to the rules specified by the Black and Ruff formatters.
> 4. Check the `Problems` tab in VS Code. There should be no linting errors related to the import statements.
> 
> ## Why make this change
> The `python.formatting.provider` setting was removed because it was set to `none`, which means that no formatting provider was being used. This is not ideal because it means that code is not being automatically formatted on save.
> 
> The `black-formatter.importStrategy` and `ruff.importStrategy` settings were added to specify that the import strategies for these formatters should be taken from the environment. This is useful because it allows for more flexible and consistent formatting across different environments.
</details>