### PR TITLE
🩹 avoid creating config before initialization

### DIFF
--- a/pyrb/brokerage/ebest/client.py
+++ b/pyrb/brokerage/ebest/client.py
@@ -20,11 +20,11 @@ class EbestClientConfig(BaseSettings):
 
 class EbestAPIClient(BrokerageAPIClient):
     BASE_URL = "https://openapi.ebestsec.co.kr:8080"
-    config = EbestClientConfig()
 
     def __init__(self, trade_mode: TradeMode = TradeMode.PAPER) -> None:
         self._trade_mode = trade_mode
         self._access_token = self._issue_access_token()
+        self._config = EbestClientConfig()
 
     def send_request(self, method: str, path: str, **kwargs: Any) -> Response:
         URL = f"{self.BASE_URL}/{path}"
@@ -49,11 +49,11 @@ class EbestAPIClient(BrokerageAPIClient):
 
         match self._trade_mode:
             case TradeMode.REAL:
-                app_key = self.config.APP_KEY
-                app_secret = self.config.APP_SECRET
+                app_key = self._config.APP_KEY
+                app_secret = self._config.APP_SECRET
             case TradeMode.PAPER:
-                app_key = self.config.PAPER_APP_KEY
-                app_secret = self.config.PAPER_APP_SECRET
+                app_key = self._config.PAPER_APP_KEY
+                app_secret = self._config.PAPER_APP_SECRET
 
         headers = {"content-type": "application/x-www-form-urlencoded"}
         params = {


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request modifies the `EbestAPIClient` class in the `client.py` file of the `pyrb/brokerage/ebest` directory. The changes involve moving the instantiation of the `EbestClientConfig` class from the class level to the instance level and using the instance attribute `_config` to access the application keys and secrets.
> 
> ## What changed
> The `EbestClientConfig` class was previously instantiated at the class level in the `EbestAPIClient` class. This has been moved to the `__init__` method, making it an instance attribute. 
> 
> The application keys and secrets were previously accessed directly from the `config` class attribute. These have been changed to be accessed from the `_config` instance attribute.
> 
> ## How to test
> To test these changes, you can create an instance of the `EbestAPIClient` class and call the `send_request` method. You should be able to see that the application keys and secrets are correctly accessed from the `_config` instance attribute. 
> 
> You can also run any existing unit tests for the `EbestAPIClient` class to ensure that the changes have not introduced any regressions.
> 
> ## Why make this change
> Moving the instantiation of the `EbestClientConfig` class to the instance level allows each instance of the `EbestAPIClient` class to have its own configuration. This is useful in scenarios where different instances may need to use different configurations.
> 
> Accessing the application keys and secrets from the `_config` instance attribute ensures that the correct configuration is used for each instance. This makes the code more robust and less prone to errors caused by shared state.
</details>