### PR TITLE
🐛 fix to create target weights from strategy

### DIFF
--- a/pyrb/service/rebalance.py
+++ b/pyrb/service/rebalance.py
@@ -29,11 +29,6 @@ class Rebalancer:
             list[Order]: A list of orders to rebalance the portfolio.
         """
 
-        def _get_weight_by_stock(portfolio: Portfolio) -> dict[str, float]:
-            """return the target weight of each stock"""
-            stocks = portfolio.holding_symbols
-            return {stock: 1 / len(stocks) for stock in stocks}
-
         def _calculate_shares_to_trade(difference_in_amount: float, current_price: float) -> int:
             """Determine the number of shares to trade based on the difference in amount."""
             return int(difference_in_amount / current_price)
@@ -55,7 +50,7 @@ class Rebalancer:
 
         self._validate_investment_amount(investment_amount)
 
-        weight_by_stock = _get_weight_by_stock(self._context.portfolio)
+        weight_by_stock = self._strategy.create_target_weights()
 
         current_prices = _fetch_current_prices(self._context, weight_by_stock)
         orders: list[Order] = []


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request removes the `_get_weight_by_stock` function from the `rebalance.py` file and replaces it with a call to `self._strategy.create_target_weights()`. This change is made to improve the flexibility of the rebalancing strategy.
> 
> ## What changed
> The `_get_weight_by_stock` function was removed from the `rebalance.py` file. This function was used to calculate the target weight of each stock in the portfolio. The function was replaced with a call to `self._strategy.create_target_weights()`, which is expected to perform the same task.
> 
> ## How to test
> To test this change, you can run the rebalancing function with a portfolio of stocks and an investment amount. The function should return a list of orders that will rebalance the portfolio according to the strategy defined in `self._strategy.create_target_weights()`.
> 
> ## Why make this change
> This change was made to improve the flexibility of the rebalancing strategy. By moving the calculation of target weights to the strategy object, different strategies can be easily implemented and used for rebalancing. This makes the code more modular and easier to maintain and extend.
</details>