### PR TITLE
🏷️ use Annotated type

### DIFF
--- a/pyrb/controller.py
+++ b/pyrb/controller.py
@@ -1,3 +1,5 @@
+from typing import Annotated
+
 import typer
 
 from pyrb.brokerage.base.client import TradeMode
@@ -18,11 +20,11 @@ def callback() -> None:
 
 @app.command()
 def holding_portfolio(
-    investment_amount: float = typer.Option(..., help="The total investment amount"),
-    brokerage: BrokerageType = typer.Option(
-        BrokerageType.EBEST, help="The name of the brokerage to use"
-    ),
-    trade_mode: TradeMode = typer.Option(TradeMode.PAPER, help="The trade mode to use"),
+    investment_amount: Annotated[float, typer.Option(..., help="The total investment amount")],
+    brokerage: Annotated[
+        BrokerageType, typer.Option(help="The name of the brokerage to use")
+    ] = BrokerageType.EBEST,
+    trade_mode: Annotated[TradeMode, typer.Option(help="The trade mode to use")] = TradeMode.PAPER,
 ) -> None:
     """
     Rebalances a holding portfolio with equal weights based on the specified options.


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request refactors the `holding_portfolio` function in `controller.py` to use Python's `Annotated` type hinting for better code readability and maintainability.
> 
> ## What changed
> The `holding_portfolio` function's parameters `investment_amount`, `brokerage`, and `trade_mode` have been updated to use `Annotated` type hinting. This change allows us to include the `typer.Option` directly in the type hint, making the code cleaner and easier to understand.
> 
> Here's the diff:
> ```diff
> -    investment_amount: float = typer.Option(..., help="The total investment amount"),
> -    brokerage: BrokerageType = typer.Option(
> -        BrokerageType.EBEST, help="The name of the brokerage to use"
> -    ),
> -    trade_mode: TradeMode = typer.Option(TradeMode.PAPER, help="The trade mode to use"),
> +    investment_amount: Annotated[float, typer.Option(..., help="The total investment amount")],
> +    brokerage: Annotated[
> +        BrokerageType, typer.Option(help="The name of the brokerage to use")
> +    ] = BrokerageType.EBEST,
> +    trade_mode: Annotated[TradeMode, typer.Option(help="The trade mode to use")] = TradeMode.PAPER,
> ```
> 
> ## How to test
> To test this change, you can run the `holding_portfolio` function with various parameters and ensure that it behaves as expected. The function's behavior should not have changed as a result of this refactoring.
> 
> ## Why make this change
> This change improves the readability and maintainability of the code by making use of Python's `Annotated` type hinting. This allows us to include additional metadata (in this case, `typer.Option`) directly in the type hint, making the code cleaner and easier to understand.
</details>