### PR TITLE
➕ add pyyaml type stub dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,4 +19,5 @@ repos:
     rev: v1.5.1
     hooks:
       - id: "mypy"
-        additional_dependencies: [click, pytest, pydantic, types-requests, typer]
+        additional_dependencies:
+          [click, pytest, pydantic, types-requests, typer, types-PyYAML]

--- a/poetry.lock
+++ b/poetry.lock
@@ -801,6 +801,17 @@ doc = ["cairosvg (>=2.5.2,<3.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "mkdocs (>=1
 test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.910)", "pytest (>=4.4.0,<8.0.0)", "pytest-cov (>=2.10.0,<5.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<4.0.0)", "rich (>=10.11.0,<14.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
 
 [[package]]
+name = "types-pyyaml"
+version = "6.0.12.12"
+description = "Typing stubs for PyYAML"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-PyYAML-6.0.12.12.tar.gz", hash = "sha256:334373d392fde0fdf95af5c3f1661885fa10c52167b14593eb856289e1855062"},
+    {file = "types_PyYAML-6.0.12.12-py3-none-any.whl", hash = "sha256:c05bc6c158facb0676674b7f11fe3960db4f389718e19e62bd2b84d6205cfd24"},
+]
+
+[[package]]
 name = "types-requests"
 version = "2.31.0.2"
 description = "Typing stubs for requests"
@@ -876,4 +887,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "533d1a61788705de9327bb688628a73b0009473494a30e479016daf9f14002cd"
+content-hash = "f1ca1ef221a2e7ebe16bb549e3c578c22d1233b0124d56a97ccfc9610bc9abd4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ pre-commit = "^3.3.3"
 pytest = "^7.4.0"
 pytest-mock = "^3.11.1"
 types-requests = "^2.31.0.2"
+types-pyyaml = "^6.0.12.12"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request adds `types-PyYAML` as a new dependency to the project. This is reflected in the changes made to `.pre-commit-config.yaml`, `poetry.lock`, and `pyproject.toml` files.
> 
> ## What changed
> - In `.pre-commit-config.yaml`, `types-PyYAML` was added to the list of additional dependencies for the `mypy` hook.
> - In `poetry.lock`, a new package entry for `types-pyyaml` was added, including its version, description, and file hashes.
> - In `pyproject.toml`, `types-pyyaml` was added to the list of project dependencies.
> 
> ## How to test
> To test these changes, follow these steps:
> 1. Pull the changes from this PR to your local environment.
> 2. Run `poetry install` to install the new dependency.
> 3. Run `pre-commit run --all-files` to check that the `mypy` hook runs successfully with the new dependency.
> 4. Run your test suite to ensure that the addition of the new dependency does not break anything.
> 
> ## Why make this change
> The addition of `types-PyYAML` provides type annotations for the PyYAML library, which can help catch potential bugs and improve code quality. This is particularly useful when using tools like `mypy` for type checking.
</details>