### PR TITLE
✨ add explicit target rebalancing

### DIFF
--- a/pyrb/controller.py
+++ b/pyrb/controller.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Annotated
 
 import typer
@@ -7,6 +8,10 @@ from pyrb.brokerage.base.order_manager import Order, OrderStatus
 from pyrb.brokerage.context import RebalanceContext, create_rebalance_context
 from pyrb.brokerage.factory import BrokerageType
 from pyrb.service.rebalance import Rebalancer
+from pyrb.service.strategy.explicit_target import (
+    ExplicitTargetRebalanceStrategy,
+    read_targets_from_source,
+)
 from pyrb.service.strategy.holding_portfolio import HoldingPortfolioRebalanceStrategy
 
 app = typer.Typer()
@@ -34,6 +39,51 @@ def holding_portfolio(
     rebalancer = Rebalancer(context, strategy)
 
     orders = rebalancer.prepare_orders(investment_amount)
+    user_confirmation = _get_confirm_for_order_submit(context, orders)
+
+    if user_confirmation:
+        rebalancer.place_orders(orders)
+    else:
+        typer.echo("No orders were placed")
+
+    _report_orders(orders)
+
+
+@app.command()
+def explicit_target(
+    targets_source: Annotated[
+        Path,
+        typer.Option(
+            ...,
+            help=(
+                "The source to read the target weights from. Supported file types: .csv, .json,"
+                " .yaml"
+            ),
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            writable=False,
+            readable=True,
+            resolve_path=True,
+        ),
+    ],
+    investment_amount: Annotated[float, typer.Option(..., help="The total investment amount")],
+    brokerage: Annotated[
+        BrokerageType, typer.Option(help="The name of the brokerage to use")
+    ] = BrokerageType.EBEST,
+    trade_mode: Annotated[TradeMode, typer.Option(help="The trade mode to use")] = TradeMode.PAPER,
+) -> None:
+    """
+    Rebalances a portfolio with explicit target weights from the specified source.
+    Sum of target weights must be 1.0. If not, the weights will be normalized.
+
+    """
+    context = create_rebalance_context(brokerage, trade_mode)
+    targets = read_targets_from_source(targets_source)
+    strategy = ExplicitTargetRebalanceStrategy(targets)
+    rebalancer = Rebalancer(context, strategy)
+
+    orders = rebalancer.prepare_orders(investment_amount=investment_amount)
     user_confirmation = _get_confirm_for_order_submit(context, orders)
 
     if user_confirmation:

--- a/pyrb/exceptions.py
+++ b/pyrb/exceptions.py
@@ -12,3 +12,7 @@ class PaperTradingSettingError(PyRbException):
 
 class OrderPlacementError(PyRbException):
     pass
+
+
+class InvalidTargetError(PyRbException):
+    pass

--- a/pyrb/service/strategy/explicit_target.py
+++ b/pyrb/service/strategy/explicit_target.py
@@ -1,3 +1,11 @@
+import csv
+import json
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+import yaml
+
+from pyrb.exceptions import InvalidTargetError
 from pyrb.service.strategy.base import Strategy
 
 
@@ -15,3 +23,114 @@ class ExplicitTargetRebalanceStrategy(Strategy):
 
     def create_target_weights(self) -> dict[str, float]:
         return self._targets
+
+
+def read_targets_from_source(source: Path) -> dict[str, float]:
+    """
+    Reads the target weights from the specified source.
+    currently surpports sources are:
+    - csv file
+    - json file
+    - yaml file
+
+    Args:
+        source (Path): The source to read the target weights from.
+
+    Returns:
+        dict[str, float]: A dictionary mapping asset symbols to target weights.
+
+    """
+    match source.suffix:
+        case ".csv":
+            return CSVTargetReader().read(source)
+        case ".json":
+            return JSONTargetReader().read(source)
+        case ".yaml":
+            return YAMLTargetReader().read(source)
+        case _:
+            raise InvalidTargetError(f"Unsupported source file type: {source.suffix}")
+
+
+class TargetReader(ABC):
+    """
+    Abstract class representing a reader for target allocations.
+    Provides functionality to read, validate, and normalize target allocations.
+
+    """
+
+    def read(self, source: Path) -> dict[str, float]:
+        """
+        Reads, validates, and normalizes target allocations from the given source.
+
+        Args:
+            source (Path): The source to read the target allocations from.
+
+        Returns:
+            dict[str, float]: A dictionary mapping asset symbols to target weights.
+
+        Raises:
+            InvalidTargetError: If the target allocations are invalid.
+        """
+        targets = self._read_targets(source)
+        self._validate_targets(targets)
+        normalized_targets = self._normalize_targets(targets)
+        return normalized_targets
+
+    def _validate_targets(self, targets: dict[str, float]) -> None:
+        def _validate_symbol(symbol: str) -> None:
+            if not isinstance(symbol, str):
+                raise InvalidTargetError("Target symbol must be a string")
+
+        def _validate_weight(weight: float) -> None:
+            if not isinstance(weight, float):
+                raise InvalidTargetError("Target weight must be a float")
+
+            if weight <= 0:
+                raise InvalidTargetError("Target weight must be positive")
+
+        if not isinstance(targets, dict):
+            raise InvalidTargetError("Targets must be a dictionary")
+
+        for symbol, weight in targets.items():
+            _validate_symbol(symbol)
+            _validate_weight(weight)
+
+    def _normalize_targets(self, targets: dict[str, float]) -> dict[str, float]:
+        total_weight = sum(targets.values())
+        normalized_targets = {symbol: weight / total_weight for symbol, weight in targets.items()}
+        return normalized_targets
+
+    @abstractmethod
+    def _read_targets(self, source: Path) -> dict[str, float]:
+        """
+        Read the targets from the given source.
+
+        Args:
+            source (Path): The source to read the target weights from.
+
+        Returns:
+            dict[str, float]: A dictionary mapping asset symbols to target weights.
+        """
+        ...
+
+
+class CSVTargetReader(TargetReader):
+    def _read_targets(self, source: Path) -> dict[str, float]:
+        with open(source, newline="") as csvfile:
+            reader = csv.DictReader(csvfile)
+            targets = {row["symbol"]: float(row["weight"]) for row in reader}
+            return targets
+
+
+class JSONTargetReader(TargetReader):
+    def _read_targets(self, source: Path) -> dict[str, float]:
+        with open(source) as jsonfile:
+            targets = json.load(jsonfile)
+            return targets
+
+
+class YAMLTargetReader(TargetReader):
+    def _read_targets(self, source: Path) -> dict[str, float]:
+        with open(source) as yamlfile:
+            targets = yaml.safe_load(yamlfile)
+            return targets


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces a new feature to the `pyrb` application that allows users to rebalance their portfolio based on explicit target weights from a specified source. The source can be a .csv, .json, or .yaml file. The sum of target weights must be 1.0, if not, the weights will be normalized. 
> 
> ## What changed
> - Added a new command `explicit_target` to the `pyrb` application that rebalances a portfolio based on explicit target weights from a specified source.
> - Added a new exception `InvalidTargetError` to handle errors related to invalid target weights.
> - Added a new module `explicit_target.py` that contains the logic for reading target weights from a specified source and rebalancing the portfolio based on these weights.
> 
> ## How to test
> 1. Checkout to this branch.
> 2. Run the `pyrb` application with the `explicit_target` command, providing a source file (.csv, .json, or .yaml) that contains the target weights for the portfolio.
> 3. Verify that the portfolio is rebalanced based on the target weights from the source file.
> 
> ## Why make this change
> This feature provides users with more flexibility in how they want to rebalance their portfolio. Instead of relying on the current portfolio holdings, users can now specify their own target weights for the portfolio. This can be useful for users who have specific investment strategies or goals.
</details>