### PR TITLE
🐛 use floor to truncate rather than int()

### DIFF
--- a/pyrb/service/rebalance.py
+++ b/pyrb/service/rebalance.py
@@ -1,3 +1,5 @@
+from math import floor
+
 from pyrb.brokerage.base.fetcher import CurrentPrice
 from pyrb.brokerage.base.order_manager import (
     Order,
@@ -31,7 +33,7 @@ class Rebalancer:
 
         def _calculate_shares_to_trade(difference_in_amount: float, current_price: float) -> int:
             """Determine the number of shares to trade based on the difference in amount."""
-            return int(difference_in_amount / current_price)
+            return floor(difference_in_amount / current_price)
 
         def _get_current_stock_amount(portfolio: Portfolio, stock: str) -> float:
             """Retrieve the current amount of a stock."""


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request modifies the `_calculate_shares_to_trade` function in `rebalance.py` to use the `floor` function from the `math` module when calculating the number of shares to trade. This ensures that the number of shares is always rounded down to the nearest whole number.
> 
> ## What changed
> The `int` function was previously used to convert the result of the division operation to an integer. However, this could potentially lead to rounding errors. The `floor` function is now used instead to ensure that the number of shares is always rounded down to the nearest whole number.
> 
> The `math` module was also imported at the top of the file to make the `floor` function available.
> 
> ## How to test
> To test this change, you can run the `prepare_orders` function with a variety of investment amounts and current prices. Verify that the number of shares to trade is always a whole number and that it is rounded down in cases where the division operation results in a fractional number.
> 
> ## Why make this change
> This change is necessary to prevent potential rounding errors when calculating the number of shares to trade. By always rounding down to the nearest whole number, we ensure that we never attempt to trade a fractional number of shares, which would not be possible.
</details>