### PR TITLE
🐛 reorder variable

### DIFF
--- a/pyrb/brokerage/ebest/client.py
+++ b/pyrb/brokerage/ebest/client.py
@@ -22,9 +22,10 @@ class EbestAPIClient(BrokerageAPIClient):
     BASE_URL = "https://openapi.ebestsec.co.kr:8080"
 
     def __init__(self, trade_mode: TradeMode = TradeMode.PAPER) -> None:
-        self._trade_mode = trade_mode
-        self._access_token = self._issue_access_token()
         self._config = EbestClientConfig()
+        self._trade_mode = trade_mode
+
+        self._access_token = self._issue_access_token()
 
     def send_request(self, method: str, path: str, **kwargs: Any) -> Response:
         URL = f"{self.BASE_URL}/{path}"


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request modifies the `EbestAPIClient` class in the `client.py` file. The change involves initializing the `_config` attribute before the `_access_token` attribute in the `__init__` method.
> 
> ## What changed
> The `_config` attribute is now initialized before the `_access_token` attribute in the `__init__` method of the `EbestAPIClient` class. This change is reflected in the following lines of code:
> 
> ```python
> def __init__(self, trade_mode: TradeMode = TradeMode.PAPER) -> None:
>     self._config = EbestClientConfig()
>     self._trade_mode = trade_mode
>     self._access_token = self._issue_access_token()
> ```
> 
> ## How to test
> To test this change, instantiate the `EbestAPIClient` class and check if the `_config` and `_access_token` attributes are properly initialized. You can do this by printing these attributes or by using them in your code and checking if they work as expected.
> 
> ## Why make this change
> This change is necessary because the `_access_token` attribute depends on the `_config` attribute. Therefore, `_config` needs to be initialized before `_access_token`. This change ensures that the `EbestAPIClient` class works correctly and prevents potential errors caused by uninitialized attributes.
</details>