### PR TITLE
✨ add asset allocate command

### DIFF
--- a/pyrb/service/strategy/asset_allocate.py
+++ b/pyrb/service/strategy/asset_allocate.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+from enum import StrEnum
 
 from pyrb.service.strategy.base import Strategy
 
@@ -20,3 +21,15 @@ class AllWeatherKRStrategy(AssetAllocationStrategy):
             "308620": 0.175,  # (국채) KODEX 미국채10년선물
             "272580": 0.15,  # (현금성 자산) TIGER 단기채권액티브
         }
+
+
+class AssetAllocationStrategyEnum(StrEnum):
+    ALL_WEATHER_KR = "all-weather-kr"
+
+
+class AssetAllocationStrtaegyFactory:
+    def create(self, strategy_type: AssetAllocationStrategyEnum) -> AssetAllocationStrategy:
+        if strategy_type == AssetAllocationStrategyEnum.ALL_WEATHER_KR:
+            return AllWeatherKRStrategy()
+        else:
+            raise ValueError(f"Unsupported strategy type: {strategy_type}")


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces a new feature to the `pyrb` application that allows users to rebalance their portfolio using a specified asset allocation strategy. The asset allocation strategy is implemented as an Enum and a Factory class for creating instances of the strategy.
> 
> ## What changed
> Two files were modified in this pull request: `controller.py` and `asset_allocate.py`.
> 
> In `controller.py`, a new command `asset_allocate` was added to the application. This command takes in three parameters: the asset allocation strategy to use, the total investment amount, and the brokerage to use. The command creates a rebalance context, creates an instance of the specified strategy using the `AssetAllocationStrtaegyFactory`, and prepares and places orders based on the strategy.
> 
> In `asset_allocate.py`, a new Enum `AssetAllocationStrategyEnum` was added to represent the different types of asset allocation strategies. A new Factory class `AssetAllocationStrtaegyFactory` was also added to create instances of the asset allocation strategy.
> 
> ## How to test
> To test this change, run the `pyrb` application with the `asset_allocate` command, specifying the asset allocation strategy, the total investment amount, and the brokerage to use. Verify that the application prepares and places orders correctly based on the specified strategy.
> 
> ## Why make this change
> This change was made to provide users with more flexibility in rebalancing their portfolio. By allowing users to specify an asset allocation strategy, they can rebalance their portfolio based on their specific investment goals and risk tolerance.
</details>