### PR TITLE
🥅 handle error from api client

### DIFF
--- a/pyrb/brokerage/ebest/client.py
+++ b/pyrb/brokerage/ebest/client.py
@@ -42,14 +42,7 @@ class EbestAPIClient(BrokerageAPIClient):
             headers["authorization"] = f"Bearer {self._access_token}"
             response = requests.request(method, URL, **kwargs)
 
-        print(response.json())
-        try:
-            response.raise_for_status()
-        except requests.HTTPError:
-            error_code = response.json()["rsp_cd"]
-            error_msg = response.json()["rsp_msg"]
-            status_code = response.status_code
-            raise APIClientError(error_code, error_msg, status_code)
+        self._raise_for_status(response)
 
         return response
 
@@ -74,5 +67,16 @@ class EbestAPIClient(BrokerageAPIClient):
         }
 
         response = requests.post(url, verify=False, headers=headers, params=params)
-        response.raise_for_status()
+
+        self._raise_for_status(response)
+
         return response.json()["access_token"]
+
+    def _raise_for_status(self, response: Response) -> None:
+        try:
+            response.raise_for_status()
+        except requests.HTTPError:
+            error_code = response.json()["rsp_cd"]
+            error_msg = response.json()["rsp_msg"]
+            status_code = response.status_code
+            raise APIClientError(error_code, error_msg, status_code)

--- a/pyrb/exceptions.py
+++ b/pyrb/exceptions.py
@@ -16,3 +16,10 @@ class OrderPlacementError(PyRbException):
 
 class InvalidTargetError(PyRbException):
     pass
+
+
+class APIClientError(PyRbException):
+    def __init__(self, client_error_code: str, client_error_message: str, status_code: int) -> None:
+        self.client_error_code = client_error_code
+        self.client_error_message = client_error_message
+        self.status_code = status_code


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces a new exception handling mechanism in the Ebest client of the pyrb brokerage package. It also adds a new exception class `APIClientError` to handle API client errors more effectively.
> 
> ## What changed
> - A new method `_raise_for_status` has been added to the `EbestClientConfig` class in `pyrb/brokerage/ebest/client.py`. This method is used to raise an `APIClientError` exception when the HTTP response status indicates an error.
> - The `send_request` and `_issue_access_token` methods in the `EbestClientConfig` class have been updated to use the new `_raise_for_status` method for error handling.
> - A new exception class `APIClientError` has been added to `pyrb/exceptions.py`. This class takes in three parameters: `client_error_code`, `client_error_message`, and `status_code`.
> 
> ## How to test
> To test these changes, you can simulate API requests that would return an HTTP error status. You should see that an `APIClientError` exception is raised with the appropriate error code, error message, and status code.
> 
> ## Why make this change
> This change improves the error handling mechanism in the Ebest client. By raising an `APIClientError` exception when an HTTP error status is received, we can provide more detailed information about the error, making it easier to debug and handle.
</details>