### PR TITLE
⚡️ optimize api request for portfolio

### DIFF
--- a/pyrb/brokerage/base/portfolio.py
+++ b/pyrb/brokerage/base/portfolio.py
@@ -12,8 +12,7 @@ class Position(BaseModel):
 
 
 class Portfolio(abc.ABC):
-    def __init__(self) -> None:
-        ...
+    def __init__(self) -> None: ...
 
     @property
     @abc.abstractmethod
@@ -57,4 +56,9 @@ class Portfolio(abc.ABC):
             Position | None: The position object for the given symbol,
                              if the symbol is not found, None will be returned.
         """
+        ...
+
+    @abc.abstractmethod
+    def refresh(self) -> None:
+        """Refreshes the portfolio object."""
         ...

--- a/pyrb/brokerage/ebest/portfolio.py
+++ b/pyrb/brokerage/ebest/portfolio.py
@@ -1,5 +1,6 @@
+from typing import Any
+
 from pydantic import NonNegativeFloat
-from requests import Response
 
 from pyrb.brokerage.base.portfolio import Portfolio, Position
 from pyrb.brokerage.ebest.client import EbestAPIClient
@@ -8,19 +9,14 @@ from pyrb.brokerage.ebest.client import EbestAPIClient
 class EbestPortfolio(Portfolio):
     def __init__(self, api_client: EbestAPIClient) -> None:
         self._api_client = api_client
+        self._serialized_portfolio: dict[str, Any] = self._fetch_portfolio()
 
     @property
     def total_value(self) -> NonNegativeFloat:
-        response = self._fetch_portfolio()
-        res = response.json()
-
-        return res["t0424OutBlock"]["sunamt"]
+        return self._serialized_portfolio["t0424OutBlock"]["sunamt"]
 
     @property
     def positions(self) -> list[Position]:
-        response = self._fetch_portfolio()
-        res = response.json()
-
         positions = [
             Position(
                 symbol=item["expcode"],
@@ -29,7 +25,7 @@ class EbestPortfolio(Portfolio):
                 average_buy_price=item["pamt"],
                 total_amount=item["appamt"],
             )
-            for item in res["t0424OutBlock1"]
+            for item in self._serialized_portfolio["t0424OutBlock1"]
         ]
 
         return positions
@@ -41,7 +37,10 @@ class EbestPortfolio(Portfolio):
     def get_position(self, symbol: str) -> Position | None:
         return next((position for position in self.positions if position.symbol == symbol), None)
 
-    def _fetch_portfolio(self) -> Response:
+    def refresh(self) -> None:
+        self._serialized_portfolio = self._fetch_portfolio()
+
+    def _fetch_portfolio(self) -> dict[str, Any]:
         """주식잔고2 TR을 조회합니다.
 
         see: https://openapi.ebestsec.co.kr/apiservice?group_id=73142d9f-1983-48d2-8543-89b75535d34c&api_id=37d22d4d-83cd-40a4-a375-81b010a4a627
@@ -61,4 +60,4 @@ class EbestPortfolio(Portfolio):
         }
 
         response = self._api_client.send_request("POST", path, headers=headers, json=body)
-        return response
+        return response.json()


### PR DESCRIPTION
To reduce the number of API calls to fetch portfolio information from brokerages, fetch portfolio information in one go, serialize it, and parse it. 
Portfolio updates can be executed by sending a message to refresh