### PR TITLE
🐛 fix order placement api

### DIFF
--- a/pyrb/brokerage/ebest/order_manager.py
+++ b/pyrb/brokerage/ebest/order_manager.py
@@ -1,11 +1,22 @@
 from requests import HTTPError
 
-from pyrb.brokerage.base.order_manager import Order, OrderManager
+from pyrb.brokerage.base.order_manager import Order, OrderManager, OrderType
 from pyrb.brokerage.ebest.client import EbestAPIClient
 from pyrb.exceptions import OrderPlacementError
 
 
 class EbestOrderManager(OrderManager):
+    _order_type_mapping: dict[OrderType, str] = {
+        OrderType.LIMIT: "00",
+        OrderType.MARKET: "03",
+        OrderType.CONDITIONAL_LIMIT: "05",
+        OrderType.BEST_LIMIT: "06",
+        OrderType.IMMEDIATE_LIMIT: "07",
+        OrderType.PREOPENING_SESSION_LAST: "61",
+        OrderType.AFTER_HOURS_LAST: "81",
+        OrderType.AFTER_HOURS_SINGLE: "82",
+    }
+
     def __init__(self, api_client: EbestAPIClient) -> None:
         self._api_client = api_client
 
@@ -19,26 +30,11 @@ class EbestOrderManager(OrderManager):
                 "IsuNo": order.symbol,
                 "OrdQty": order.quantity,
                 "OrdPrc": order.price,
-                "BnsTpCode": "2",
-                "OrdprcPtnCode": "00",
-                "PrgmOrdprcPtnCode": "00",
-                "StslAbleYn": "0",
-                "StslOrdprcTpCode": "0",
-                "CommdaCode": "41",
+                "BnsTpCode": "2" if order.side == "BUY" else "1",
+                "OrdprcPtnCode": self._order_type_mapping[order.order_type],
                 "MgntrnCode": "000",
                 "LoanDt": "",
-                "MbrNo": "000",
                 "OrdCndiTpCode": "0",
-                "StrtgCode": " ",
-                "GrpId": " ",
-                "OrdSeqNo": 0,
-                "PtflNo": 0,
-                "BskNo": 0,
-                "TrchNo": 0,
-                "ItemNo": 0,
-                "OpDrtnNo": "0",
-                "LpYn": "0",
-                "CvrgTpCode": "0",
             }
         }
 


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> # TL;DR
> This pull request refactors the `EbestOrderManager` class in the `order_manager.py` file. It introduces a mapping for different order types and simplifies the `place_order` method by removing unnecessary parameters.
> 
> # What changed
> A dictionary `_order_type_mapping` was added to map `OrderType` enum values to their corresponding string codes used by the Ebest API. This allows for easier and more readable order type handling.
> 
> The `place_order` method was simplified by removing parameters that were not necessary for order placement. The `BnsTpCode` parameter was also updated to dynamically set the value based on the order side (buy or sell).
> 
> # How to test
> To test these changes, you can create an instance of `EbestOrderManager` and call the `place_order` method with different types of orders. Ensure that the correct order type code is used in the API request and that the order is successfully placed.
> 
> # Why make this change
> This change improves the readability and maintainability of the code by removing unnecessary parameters and introducing a clear mapping for order types. It also makes the `place_order` method more flexible by allowing it to handle different types of orders.
</details>