### PR TITLE
🔒️ verify request

### DIFF
--- a/pyrb/brokerage/ebest/client.py
+++ b/pyrb/brokerage/ebest/client.py
@@ -66,7 +66,7 @@ class EbestAPIClient(BrokerageAPIClient):
             "scope": "oob",
         }
 
-        response = requests.post(url, verify=False, headers=headers, params=params)
+        response = requests.post(url, headers=headers, params=params)
 
         self._raise_for_status(response)
 


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request removes the `verify=False` parameter from the `requests.post` method in the `_issue_access_token` function of the `client.py` file in the `ebest` module.
> 
> ## What changed
> The `verify=False` parameter was removed from the `requests.post` method. This parameter disables SSL certificate verification, which can lead to security vulnerabilities. By removing this parameter, the `requests.post` method will now verify SSL certificates by default.
> 
> ```diff
> -        response = requests.post(url, verify=False, headers=headers, params=params)
> +        response = requests.post(url, headers=headers, params=params)
> ```
> 
> ## How to test
> To test this change, you can run any function that calls the `_issue_access_token` function and ensure that it still works as expected. You should also check that no SSL certificate errors are thrown when the `requests.post` method is called.
> 
> ## Why make this change
> This change was made to improve the security of the `ebest` module. Disabling SSL certificate verification can lead to man-in-the-middle attacks, where an attacker can intercept and potentially alter the data being sent over the network. By verifying SSL certificates, we can ensure that the data is being sent over a secure connection.
</details>