### PR TITLE
✨ add portfolio command

### DIFF
--- a/pyrb/controller.py
+++ b/pyrb/controller.py
@@ -129,6 +129,30 @@ def asset_allocate(
     _report_orders(orders)
 
 
+@app.command()
+def portfolio(
+    brokerage: Annotated[
+        BrokerageType, typer.Option(help="The name of the brokerage to use")
+    ] = BrokerageType.EBEST,
+    trade_mode: Annotated[TradeMode, typer.Option(help="The trade mode to use")] = TradeMode.PAPER,
+) -> None:
+    context = create_rebalance_context(brokerage, trade_mode)
+    context.portfolio.refresh()
+
+    table = Table("Symbol", "Quantity", "Sellable Quantity", "Average Buy Price", "Total Amount")
+
+    for position in context.portfolio.positions:
+        table.add_row(
+            position.symbol,
+            str(position.quantity),
+            str(position.sellable_quantity),
+            str(position.average_buy_price),
+            str(position.total_amount),
+        )
+
+    console.print(table)
+
+
 def _get_confirm_for_order_submit(context: RebalanceContext, orders: list[Order]) -> bool:
     """Confirm orders to the user and return the user's confirmation."""
     table = Table(


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request adds a new command `portfolio` to the application. This command allows users to view their portfolio details including symbol, quantity, sellable quantity, average buy price, and total amount for each position.
> 
> ## What changed
> A new command `portfolio` was added to the `controller.py` file. This command uses the `create_rebalance_context` function to create a context with the given brokerage and trade mode. It then refreshes the portfolio and creates a table with the details of each position in the portfolio. The table is then printed to the console.
> 
> ## How to test
> To test this change, you can run the application with the `portfolio` command. You should see a table printed to the console with the details of each position in your portfolio. You can also test this command with different brokerages and trade modes to ensure it works correctly in all scenarios.
> 
> ## Why make this change
> This change was made to provide users with a quick and easy way to view the details of their portfolio. This can be useful for users who want to keep track of their investments and see how they are performing.
</details>