### PR TITLE
✨add set account command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,4 +20,4 @@ repos:
     hooks:
       - id: "mypy"
         additional_dependencies:
-          [click, pytest, pydantic, types-requests, typer, types-PyYAML]
+          [click, pytest, pydantic, types-requests, typer, types-PyYAML, types-toml]

--- a/poetry.lock
+++ b/poetry.lock
@@ -777,6 +777,17 @@ files = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+
+[[package]]
 name = "typer"
 version = "0.9.0"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
@@ -824,6 +835,17 @@ files = [
 
 [package.dependencies]
 types-urllib3 = "*"
+
+[[package]]
+name = "types-toml"
+version = "0.10.8.7"
+description = "Typing stubs for toml"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-toml-0.10.8.7.tar.gz", hash = "sha256:58b0781c681e671ff0b5c0319309910689f4ab40e8a2431e205d70c94bb6efb1"},
+    {file = "types_toml-0.10.8.7-py3-none-any.whl", hash = "sha256:61951da6ad410794c97bec035d59376ce1cbf4453dc9b6f90477e81e4442d631"},
+]
 
 [[package]]
 name = "types-urllib3"
@@ -887,4 +909,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "f1ca1ef221a2e7ebe16bb549e3c578c22d1233b0124d56a97ccfc9610bc9abd4"
+content-hash = "df0b5e69e72c0b317af3f03f0f1cfe8dd17147dc520d49465f4bf394e75e9b52"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ pydantic = "^2.1.1"
 requests = "^2.31.0"
 pydantic-settings = "^2.0.3"
 typer = {extras = ["all"], version = "^0.9.0"}
+toml = "^0.10.2"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "0.0.291"
@@ -25,6 +26,7 @@ pytest = "^7.4.0"
 pytest-mock = "^3.11.1"
 types-requests = "^2.31.0.2"
 types-pyyaml = "^6.0.12.12"
+types-toml = "^0.10.8.7"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyrb/controller/cli/account.py
+++ b/pyrb/controller/cli/account.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from pyrb.model.account import EbestAccount
+from pyrb.repository.account import LocalConfigAccountRepository
+from pyrb.service.account import AccountService
+
+app = typer.Typer()
+APP_NAME = "pyrb"  # TODO: parse from pyproject.toml and move to constants.py
+
+
+@app.command("set")
+def set(
+    app_key: Annotated[str, typer.Option(..., help="app key for the brokerage", prompt=True)],
+    app_secret: Annotated[str, typer.Option(..., help="app secret for the brokerage", prompt=True)],
+) -> None:
+    app_config_dir = Path(typer.get_app_dir(APP_NAME))
+    accounts_config_path = app_config_dir / "accounts"
+
+    account_repo = LocalConfigAccountRepository(accounts_config_path)
+    account_service = AccountService(account_repo)
+
+    account = EbestAccount(app_key=app_key, app_secret=app_secret)
+    account_service.set(account)

--- a/pyrb/controller/cli/account.py
+++ b/pyrb/controller/cli/account.py
@@ -19,8 +19,8 @@ def set(
     app_config_dir = Path(typer.get_app_dir(APP_NAME))
     accounts_config_path = app_config_dir / "accounts"
 
-    account_repo = LocalConfigAccountRepository(accounts_config_path)
-    account_service = AccountService(account_repo)
+    account_service = AccountService(
+        account_repo=LocalConfigAccountRepository(accounts_config_path)
+    )
 
-    account = EbestAccount(app_key=app_key, app_secret=app_secret)
-    account_service.set(account)
+    account_service.set(account=EbestAccount(app_key=app_key, app_secret=app_secret))

--- a/pyrb/controller/cli/main.py
+++ b/pyrb/controller/cli/main.py
@@ -5,6 +5,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from pyrb.controller.cli.account import app as account_app
 from pyrb.repository.brokerage.base.client import TradeMode
 from pyrb.repository.brokerage.base.order_manager import Order, OrderSide, OrderStatus
 from pyrb.repository.brokerage.context import RebalanceContext, create_rebalance_context
@@ -21,6 +22,7 @@ from pyrb.service.strategy.explicit_target import (
 from pyrb.service.strategy.holding_portfolio import HoldingPortfolioRebalanceStrategy
 
 app = typer.Typer()
+app.add_typer(account_app, name="account")
 console = Console()
 
 

--- a/pyrb/model/account.py
+++ b/pyrb/model/account.py
@@ -1,10 +1,13 @@
 from abc import ABC
 from typing import Annotated
 
+import toml
 from pydantic import BaseModel, Field
 
 
-class Account(BaseModel, ABC): ...
+class Account(BaseModel, ABC):
+    def to_toml(self) -> str:
+        return toml.dumps(self.model_dump())
 
 
 class EbestAccount(Account):

--- a/pyrb/model/account.py
+++ b/pyrb/model/account.py
@@ -1,0 +1,12 @@
+from abc import ABC
+from typing import Annotated
+
+from pydantic import BaseModel, Field
+
+
+class Account(BaseModel, ABC): ...
+
+
+class EbestAccount(Account):
+    app_key: Annotated[str, Field(...)]
+    app_secret: Annotated[str, Field(...)]

--- a/pyrb/repository/account.py
+++ b/pyrb/repository/account.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+from pyrb.model.account import Account
+
+
+class AccountRepository(ABC):
+    @abstractmethod
+    def set_account(self, account: Account) -> None: ...
+
+
+class LocalConfigAccountRepository(AccountRepository):
+    def __init__(self, config_path: Path) -> None:
+        self._config_path = config_path
+        # create directory if not exists
+        self._config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def set_account(self, account: Account) -> None:
+        with open(self._config_path, "w") as f:
+            f.write(account.model_dump_json())

--- a/pyrb/repository/account.py
+++ b/pyrb/repository/account.py
@@ -17,4 +17,4 @@ class LocalConfigAccountRepository(AccountRepository):
 
     def set_account(self, account: Account) -> None:
         with open(self._config_path, "w") as f:
-            f.write(account.model_dump_json())
+            f.write(account.to_toml())

--- a/pyrb/repository/account.py
+++ b/pyrb/repository/account.py
@@ -6,7 +6,7 @@ from pyrb.model.account import Account
 
 class AccountRepository(ABC):
     @abstractmethod
-    def set_account(self, account: Account) -> None: ...
+    def set(self, account: Account) -> None: ...
 
 
 class LocalConfigAccountRepository(AccountRepository):
@@ -15,6 +15,6 @@ class LocalConfigAccountRepository(AccountRepository):
         # create directory if not exists
         self._config_path.parent.mkdir(parents=True, exist_ok=True)
 
-    def set_account(self, account: Account) -> None:
+    def set(self, account: Account) -> None:
         with open(self._config_path, "w") as f:
             f.write(account.to_toml())

--- a/pyrb/service/account.py
+++ b/pyrb/service/account.py
@@ -7,4 +7,4 @@ class AccountService:
         self._account_repo = account_repo
 
     def set(self, account: Account) -> None:
-        self._account_repo.set_account(account)
+        self._account_repo.set(account)

--- a/pyrb/service/account.py
+++ b/pyrb/service/account.py
@@ -1,0 +1,10 @@
+from pyrb.model.account import Account
+from pyrb.repository.account import AccountRepository
+
+
+class AccountService:
+    def __init__(self, account_repo: AccountRepository) -> None:
+        self._account_repo = account_repo
+
+    def set(self, account: Account) -> None:
+        self._account_repo.set_account(account)

--- a/tests/services/test_account.py
+++ b/tests/services/test_account.py
@@ -1,3 +1,4 @@
+import tempfile
 from pathlib import Path
 
 from pyrb.model.account import Account
@@ -7,17 +8,18 @@ from pyrb.service.account import AccountService
 
 def test_sut_set_account_with_local_config_account_repository() -> None:
     # given
-    config_path = Path("tests/services/__pycache__/test_account.py").parent / "accounts"
-    account_repo = LocalConfigAccountRepository(config_path)
-    account_service = AccountService(account_repo)
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        config_path = Path(tmpdirname) / "accounts"
+        account_repo = LocalConfigAccountRepository(config_path)
+        account_service = AccountService(account_repo)
 
-    class FakeAccount(Account):
-        foo: str
+        class FakeAccount(Account):
+            foo: str
 
-    # when
-    account = FakeAccount(foo="bar")
-    account_service.set(account)
+        # when
+        account = FakeAccount(foo="bar")
+        account_service.set(account)
 
-    # then
-    with open(config_path) as f:
-        assert f.read() == account.to_toml()
+        # then
+        with open(config_path) as f:
+            assert f.read() == account.to_toml()

--- a/tests/services/test_account.py
+++ b/tests/services/test_account.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from pyrb.model.account import Account
+from pyrb.repository.account import LocalConfigAccountRepository
+from pyrb.service.account import AccountService
+
+
+def test_sut_set_account_with_local_config_account_repository() -> None:
+    # given
+    config_path = Path("tests/services/__pycache__/test_account.py").parent / "accounts"
+    account_repo = LocalConfigAccountRepository(config_path)
+    account_service = AccountService(account_repo)
+
+    class FakeAccount(Account):
+        foo: str
+
+    # when
+    account = FakeAccount(foo="bar")
+    account_service.set(account)
+
+    # then
+    with open(config_path) as f:
+        assert f.read() == account.to_toml()


### PR DESCRIPTION
✨add set account command

♻️ write account config as toml not json

✅ add test code

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request adds support for managing brokerage accounts in the CLI application. It introduces new files and modifies existing ones to implement the functionality.
> 
> ## What changed
> - Added a new file `pyrb/controller/cli/account.py` that contains the implementation for managing brokerage accounts.
> - Modified the file `.pre-commit-config.yaml` to include the new dependency `types-toml`.
> - Modified the file `poetry.lock` to include the new package `types-toml`.
> - Modified the file `pyproject.toml` to include the new dependency `toml` and the new package `types-toml`.
> - Added a new file `pyrb/model/account.py` that defines the `Account` model and its subclasses.
> - Added a new file `pyrb/repository/account.py` that defines the `AccountRepository` interface and its implementation `LocalConfigAccountRepository`.
> - Added a new file `pyrb/service/account.py` that defines the `AccountService` class.
> - Added a new file `tests/services/test_account.py` that contains tests for the `AccountService` class.
> 
> ## How to test
> 1. Run the application and check if the new `account` command is available.
> 2. Use the `account set` command to set the app key and app secret for a brokerage account.
> 3. Verify that the account information is stored correctly in the configuration file.
> 
> ## Why make this change
> This change was made to enhance the functionality of the CLI application by adding support for managing brokerage accounts. This allows users to easily set and store their app key and app secret for different brokerage accounts, making it more convenient to switch between accounts when using the application.
</details>