### PR TITLE
🧑‍💻 update vscode configuation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,9 @@
 {
     "recommendations": [
-        "charliermarsh.ruff", 
+        "charliermarsh.ruff",
         "ms-python.black-formatter",
         "ms-python.python",
-        "ms-python.vscode-pylance"
+        "ms-python.vscode-pylance",
+        "ms-python.mypy-type-checker",
     ]
-  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,6 @@
   "editor.formatOnSave": true,
   "python.languageServer": "Pylance",
   "python.analysis.typeCheckingMode": "off",
-  "python.linting.mypyEnabled": true,
-  "python.linting.enabled": true,
   "[python]": {
     "editor.defaultFormatter": "ms-python.black-formatter",
     "editor.codeActionsOnSave": {
@@ -12,6 +10,7 @@
   },
   "black-formatter.importStrategy": "fromEnvironment",
   "ruff.importStrategy": "fromEnvironment",
+  "mypy-type-checker.importStrategy": "fromEnvironment",
   "git.branchProtection": [
     "main"
   ],


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request adds the `mypy-type-checker` extension to the recommended extensions in `.vscode/extensions.json` and updates the import strategy for it in `.vscode/settings.json`. It also removes redundant linting settings.
> 
> ## What changed
> - Added `mypy-type-checker` to the list of recommended extensions in `.vscode/extensions.json`.
> - Removed redundant linting settings from `.vscode/settings.json`.
> - Added `mypy-type-checker.importStrategy` to `.vscode/settings.json` with the value `fromEnvironment`.
> 
> ## How to test
> 1. Checkout to this branch.
> 2. Open the project in VS Code.
> 3. Ensure that the `mypy-type-checker` extension is recommended.
> 4. Check the settings in `.vscode/settings.json` to ensure the changes are reflected.
> 
> ## Why make this change
> The `mypy-type-checker` extension provides static type checking for Python, which can help catch potential bugs before runtime. By adding it to the recommended extensions, we ensure that all developers working on this project have access to this tool. The changes in `.vscode/settings.json` are to ensure that the extension works correctly and to remove redundant settings.
</details>