### PR TITLE
🚸 show return of each position in portfolio

### DIFF
--- a/pyrb/controller/cli/main.py
+++ b/pyrb/controller/cli/main.py
@@ -158,7 +158,14 @@ def portfolio() -> None:
     context = create_rebalance_context(account)
     context.portfolio.refresh()
 
-    table = Table("Symbol", "Quantity", "Sellable Quantity", "Average Buy Price", "Total Amount")
+    table = Table(
+        "Symbol",
+        "Quantity",
+        "Sellable Quantity",
+        "Average Buy Price",
+        "Total Amount",
+        "Return (%)",
+    )
 
     for position in context.portfolio.positions:
         table.add_row(
@@ -167,6 +174,7 @@ def portfolio() -> None:
             str(position.sellable_quantity),
             str(position.average_buy_price),
             str(position.total_amount),
+            str(position.rtn),
         )
 
     console.print(table)

--- a/pyrb/model/position.py
+++ b/pyrb/model/position.py
@@ -7,3 +7,4 @@ class Position(BaseModel):
     sellable_quantity: PositiveInt  # 매도가능수량
     average_buy_price: PositiveFloat  # 매입단가
     total_amount: PositiveFloat  # 평가금액
+    rtn: float  # 수익률

--- a/pyrb/repository/brokerage/ebest/portfolio.py
+++ b/pyrb/repository/brokerage/ebest/portfolio.py
@@ -25,6 +25,7 @@ class EbestPortfolio(Portfolio):
                 sellable_quantity=item["mdposqt"],
                 average_buy_price=item["pamt"],
                 total_amount=item["appamt"],
+                rtn=item["sunikrt"],
             )
             for item in self._serialized_portfolio["t0424OutBlock1"]
         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ class FakePortfolio(Portfolio):
                 sellable_quantity=100,
                 average_buy_price=100,
                 total_amount=10000,
+                rtn=0.0,
             ),
             Position(
                 symbol="005930",
@@ -32,6 +33,7 @@ class FakePortfolio(Portfolio):
                 sellable_quantity=50,
                 average_buy_price=150,
                 total_amount=7500,
+                rtn=0.0,
             ),
         ]
 


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request adds a new feature to the portfolio table in the CLI. It now includes a "Return (%)" column that displays the return rate for each position in the portfolio.
> 
> ## What changed
> Three files were modified to implement this feature:
> 
> 1. `pyrb/controller/cli/main.py`: The portfolio table in the CLI was updated to include a new column "Return (%)".
> 
> 2. `pyrb/model/position.py`: A new attribute `rtn` was added to the `Position` class to store the return rate.
> 
> 3. `pyrb/repository/brokerage/ebest/portfolio.py`: The `positions` method was updated to include the return rate when creating a `Position` object.
> 
> The test file `tests/conftest.py` was also updated to include the return rate when creating test `Position` objects.
> 
> ## How to test
> To test this feature, you can run the CLI and check the portfolio table. It should now include a "Return (%)" column. You can also run the test suite to ensure that all tests pass with the new changes.
> 
> ## Why make this change
> This change was made to provide more information to the user about their portfolio. The return rate is a crucial piece of information when evaluating the performance of a position. By including it in the portfolio table, users can easily see how well each position is doing.
</details>