### PR TITLE
⚡️ reduce unnecessary api call

### DIFF
--- a/pyrb/controller/cli/main.py
+++ b/pyrb/controller/cli/main.py
@@ -156,7 +156,6 @@ def portfolio() -> None:
 
     account = account_service.get()
     context = create_rebalance_context(account)
-    context.portfolio.refresh()
 
     table = Table(
         "Symbol",


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request removes the line `context.portfolio.refresh()` from the `portfolio()` function in `main.py`. 
> 
> ## What changed
> The `context.portfolio.refresh()` line was removed from the `portfolio()` function in `main.py`. This line was responsible for refreshing the portfolio context. 
> 
> ```diff
> @@ -156,7 +156,6 @@ def portfolio() -> None:
> 
>      account = account_service.get()
>      context = create_rebalance_context(account)
> -    context.portfolio.refresh()
> 
>      table = Table(
>          "Symbol",
> ```
> 
> ## How to test
> To test this change, follow these steps:
> 
> 1. Pull the changes from this branch into your local environment.
> 2. Run the `portfolio()` function and observe the output.
> 3. Ensure that the function still behaves as expected without the `context.portfolio.refresh()` line.
> 
> ## Why make this change
> This change was made because the `context.portfolio.refresh()` line was found to be unnecessary. The portfolio context does not need to be refreshed at this point in the code, and removing this line simplifies the function and improves performance.
</details>