### PR TITLE
🐛 handle error for order placement with 200 status code

### DIFF
--- a/pyrb/repository/brokerage/ebest/order_manager.py
+++ b/pyrb/repository/brokerage/ebest/order_manager.py
@@ -41,6 +41,8 @@ class EbestOrderManager(OrderManager):
         }
 
         try:
-            self._api_client.send_request("POST", path, headers=headers, json=body)
+            resp = self._api_client.send_request("POST", path, headers=headers, json=body).json()
+            if resp.get("rsp_cd") != "00040":
+                raise OrderPlacementError(resp)
         except HTTPError as e:
             raise OrderPlacementError(e)


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request modifies the `place_order` method in the `order_manager.py` file to handle unsuccessful order placements more effectively. It now checks the response code from the API client and raises an `OrderPlacementError` if the response code is not "00040" (indicating a successful order placement).
> 
> ## What changed
> The `place_order` method in the `order_manager.py` file was modified. Previously, it would send a request to the API client and not check the response. Now, it checks the response code and raises an `OrderPlacementError` if the response code is not "00040".
> 
> ## How to test
> To test this change, you can try placing an order using the `place_order` method. If the order placement is unsuccessful, the method should now raise an `OrderPlacementError`.
> 
> ## Why make this change
> This change was made to improve error handling in the `place_order` method. By checking the response code from the API client, we can ensure that the method behaves as expected when an order placement is unsuccessful. This will make it easier to debug issues with order placement in the future.
</details>