### PR TITLE
♻️ Refactor account creation and service instantiation

### DIFF
--- a/pyrb/controller/cli/account.py
+++ b/pyrb/controller/cli/account.py
@@ -20,6 +20,12 @@ def set(
         BrokerageType, typer.Option(help="brokerage type", case_sensitive=False)
     ] = BrokerageType.EBEST,
 ) -> None:
+    account_service = create_account_service()
+    account = AccountFactory.create(brokerage, app_key=app_key, app_secret=app_secret)
+    account_service.set(account=account)
+
+
+def create_account_service() -> AccountService:
     app_config_dir = Path(typer.get_app_dir(APP_NAME))
     accounts_config_path = app_config_dir / "accounts"
 
@@ -27,5 +33,4 @@ def set(
         account_repo=LocalConfigAccountRepository(accounts_config_path)
     )
 
-    account = AccountFactory.create(brokerage, app_key=app_key, app_secret=app_secret)
-    account_service.set(account=account)
+    return account_service


### PR DESCRIPTION
instantiation

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request refactors the code in the `pyrb/controller/cli/main.py` file to improve readability and maintainability. It introduces a new function `_create_context()` to create a `RebalanceContext` object, and a new function `_place_orders()` to handle order placement. It also removes redundant code and improves code organization.
> 
> ## What changed
> - Added a new function `create_account_service()` in `pyrb/controller/cli/account.py` to create an `AccountService` object.
> - Refactored the code in `pyrb/controller/cli/main.py` to use the new `create_account_service()` function and improve code organization.
> - Introduced a new function `_create_context()` to create a `RebalanceContext` object.
> - Introduced a new function `_place_orders()` to handle order placement.
> - Removed redundant code and improved code readability.
> 
> ## How to test
> 1. Checkout this branch.
> 2. Run the test suite to ensure there are no regressions.
> 3. Test the `set()` function in `pyrb/controller/cli/account.py` to ensure that the `account_service` is created correctly.
> 4. Test the `holding_portfolio()`, `explicit_target()`, `asset_allocate()`, and `portfolio()` functions in `pyrb/controller/cli/main.py` to ensure that the rebalancing and order placement functionalities work as expected.
> 
> ## Why make this change
> - The code in `pyrb/controller/cli/main.py` was becoming difficult to read and maintain due to its length and lack of organization.
> - By introducing new functions and refactoring the code, we can improve code readability and maintainability.
> - The new functions `_create_context()` and `_place_orders()` help to separate concerns and improve code organization.
> - Removing redundant code and improving code readability will make it easier for developers to understand and modify the code in the future.
</details>