### PR TITLE
📝 parse python version of the badge from pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pyrb - Python Rebalancer
 
-![Python](https://img.shields.io/badge/Python-v3.11-blue)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyrb)
 ![License](https://img.shields.io/badge/License-MIT-green)
 ![Supported Brokerages](https://img.shields.io/badge/Supported%20Brokerages-EBest-orange)
 


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> # Pull Request Description
> 
> ## TL;DR
> This pull request updates the Python version badge in the README.md file to reflect the Python versions supported by the `pyrb` package on PyPI.
> 
> ## What changed
> The Python version badge in the README.md file was changed from a static badge showing `v3.11` to a dynamic badge from PyPI that shows the Python versions supported by the `pyrb` package.
> 
> ```diff
> -![Python](https://img.shields.io/badge/Python-v3.11-blue)
> +![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyrb)
> ```
> 
> ## How to test
> To test this change, you can view the README.md file on the repository's main page. The Python version badge should now reflect the Python versions supported by the `pyrb` package on PyPI.
> 
> ## Why make this change
> This change was made to provide more accurate and up-to-date information about the Python versions supported by the `pyrb` package. This will help users to know if their Python version is compatible with the `pyrb` package.
</details>