### PR TITLE
📝 update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## 설치 방법
 
-Pip 혹은 Poetry로 `pyrb`를 직접 설치할 수 있습니다:
+Pip 혹은 Poetry로 `pyrb`를 직접 설치할 수 있습니다 (python 3.8 이상 버전이 필요합니다.):
 
 - Pip
 


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request updates the README.md file to specify that Python 3.8 or higher is required to install `pyrb` using Pip or Poetry.
> 
> ## What changed
> A line in the README.md file was updated from:
> ```
> Pip 혹은 Poetry로 `pyrb`를 직접 설치할 수 있습니다:
> ```
> to:
> ```
> Pip 혹은 Poetry로 `pyrb`를 직접 설치할 수 있습니다 (python 3.8 이상 버전이 필요합니다.):
> ```
> 
> ## How to test
> To test this change, you can view the README.md file and verify that the installation instructions now specify the Python version requirement.
> 
> ## Why make this change
> This change was made to provide clear instructions to users about the Python version requirement for installing `pyrb`. This will help users avoid potential issues during installation if they are using an unsupported version of Python.
</details>