### PR TITLE
🐛 do not report order without confirmation

### DIFF
--- a/pyrb/controllers/cli/main.py
+++ b/pyrb/controllers/cli/main.py
@@ -121,9 +121,23 @@ def _create_context() -> RebalanceContext:
 
 
 def _place_orders(context: RebalanceContext, rebalancer: Rebalancer, orders: list[Order]) -> None:
+    """
+    Places the given orders using the provided rebalancer.
+    Before placing the orders, the user is asked to confirm the orders.
+    If the user does not confirm, the orders are not placed.
+
+    Args:
+        context (RebalanceContext): The context for rebalancing.
+        rebalancer (Rebalancer): The rebalancer object used for placing orders.
+        orders (list[Order]): The list of orders to be placed.
+
+    Returns:
+        None
+    """
     user_confirmation = _get_confirm_for_order_submit(context, orders)
     if not user_confirmation:
         typer.echo("No orders were placed")
+        return
 
     results = rebalancer.place_orders(orders)
     _report_orders(results)


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request adds a user confirmation step before placing orders in the `_place_orders` function. If the user does not confirm, the orders are not placed and a message is displayed.
> 
> ## What changed
> The `_place_orders` function in `pyrb/controllers/cli/main.py` has been updated. A user confirmation step has been added before the orders are placed. If the user does not confirm, the function will return and no orders will be placed. 
> 
> ## How to test
> To test this change, follow these steps:
> 1. Run the rebalancer with a set of orders.
> 2. When prompted, confirm or deny the order placement.
> 3. If confirmed, the orders should be placed as usual.
> 4. If denied, no orders should be placed and a message "No orders were placed" should be displayed.
> 
> ## Why make this change
> This change adds an extra layer of confirmation before placing orders, which can prevent accidental order placements. This is especially useful in a trading environment where order placements can have significant financial implications.
</details>