### PR TITLE
👷 fix workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,11 +46,11 @@ jobs:
 
           if [ "$VERSION" != "$LATEST_RELEASE" ]; then
             echo "Version has changed."
-            echo "version_changed=true" >> $GITHUB_ENV
-            echo "new_version=$VERSION" >> $GITHUB_ENV
+            echo "version_changed=true" >> $GITHUB_OUTPUT
+            echo "new_version=$VERSION" >> $GITHUB_OUTPUT
           else
             echo "No version change detected."
-            echo "version_changed=false" >> $GITHUB_ENV
+            echo "version_changed=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Create Release


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request modifies the release workflow file to write the `version_changed` and `new_version` variables to `$GITHUB_OUTPUT` instead of `$GITHUB_ENV`.
> 
> ## What changed
> In the release workflow file, the `version_changed` and `new_version` variables were previously written to `$GITHUB_ENV`. This pull request changes the destination to `$GITHUB_OUTPUT`.
> 
> ## How to test
> To test this change, you can trigger the release workflow and check the output. If the version has changed, `version_changed` should be `true` and `new_version` should contain the new version. If the version has not changed, `version_changed` should be `false`.
> 
> ## Why make this change
> This change is necessary to ensure that the `version_changed` and `new_version` variables are correctly set and accessible in subsequent steps of the workflow. Writing these variables to `$GITHUB_OUTPUT` allows them to be used as output variables in other steps, providing more flexibility and control over the workflow.
</details>