### PR TITLE
👷 add publishing workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,30 @@
+name: Publish Python Package
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.11"
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+
+      - name: Configure Poetry
+        run: |
+          poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Build and publish
+        run: |
+          poetry publish --build


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request adds a new GitHub Actions workflow for publishing our Python package to PyPI automatically whenever a new release is created.
> 
> ## What changed
> A new file `.github/workflows/publish.yaml` was added. This file defines a GitHub Actions workflow that triggers on the `release` event. The workflow includes steps to checkout the repository, setup Python, install Poetry, configure Poetry with PyPI API token, and finally build and publish the package to PyPI.
> 
> ## How to test
> To test this change, you can create a new release on GitHub. Once the release is created, the workflow should trigger and you should see the package published on PyPI.
> 
> ## Why make this change
> This change automates the process of publishing our Python package to PyPI. This ensures that the package is always up-to-date with the latest release and reduces the manual effort required to publish the package.
</details>