### PR TITLE
✏️ fix typo

### DIFF
--- a/pyrb/controllers/cli/main.py
+++ b/pyrb/controllers/cli/main.py
@@ -14,7 +14,7 @@ from pyrb.models.order import Order, OrderPlacementResult
 from pyrb.repositories.brokerages.context import RebalanceContext, create_rebalance_context
 from pyrb.services.rebalance import Rebalancer
 from pyrb.services.strategy.asset_allocate import (
-    AssetAllocationStrtegyFactory,
+    AssetAllocationStrategyFactory,
 )
 from pyrb.services.strategy.explicit_target import (
     ExplicitTargetRebalanceStrategy,
@@ -95,7 +95,7 @@ def asset_allocate(
     """
     context = _create_context()
 
-    strategy = AssetAllocationStrtegyFactory().create(strategy)
+    strategy = AssetAllocationStrategyFactory().create(strategy)
     rebalancer = Rebalancer(context, strategy)
 
     orders = rebalancer.prepare_orders(investment_amount=investment_amount)

--- a/pyrb/services/strategy/asset_allocate.py
+++ b/pyrb/services/strategy/asset_allocate.py
@@ -23,7 +23,7 @@ class AllWeatherKRStrategy(AssetAllocationStrategy):
         }
 
 
-class AssetAllocationStrtegyFactory:
+class AssetAllocationStrategyFactory:
     def create(self, strategy_type: AssetAllocationStrategyEnum) -> AssetAllocationStrategy:
         if strategy_type == AssetAllocationStrategyEnum.ALL_WEATHER_KR:
             return AllWeatherKRStrategy()


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request corrects a typo in the class name `AssetAllocationStrtegyFactory` to `AssetAllocationStrategyFactory` in two files: `main.py` and `asset_allocate.py`.
> 
> ## What changed
> The class name `AssetAllocationStrtegyFactory` was misspelled in both `main.py` and `asset_allocate.py`. This has been corrected to `AssetAllocationStrategyFactory`.
> 
> ## How to test
> To test this change, you can run any unit tests that use the `AssetAllocationStrategyFactory` class. If there are no existing tests, you can create a new instance of the `AssetAllocationStrategyFactory` class and call its methods to ensure it's working as expected.
> 
> ## Why make this change
> This change is necessary to maintain code readability and consistency. It also prevents potential bugs that could be caused by the misspelled class name.
</details>