### PR TITLE
🩹 Fix return format in EbestPortfolio

### DIFF
--- a/pyrb/repositories/brokerages/ebest/portfolio.py
+++ b/pyrb/repositories/brokerages/ebest/portfolio.py
@@ -29,7 +29,7 @@ class EbestPortfolio(Portfolio):
                 sellable_quantity=item["mdposqt"],
                 average_buy_price=item["pamt"],
                 total_amount=item["appamt"],
-                rtn=item["sunikrt"],
+                rtn=float(item["sunikrt"]) / 100,
             )
             for item in self._serialized_portfolio["t0424OutBlock1"]
         ]


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request modifies the `portfolio.py` file in the `ebest` brokerage repository. The change involves converting the `rtn` value from a string to a float and dividing it by 100.
> 
> ## What changed
> In the `positions` method of the `portfolio.py` file, the `rtn` value was previously returned as a string. This pull request changes the `rtn` value to a float and divides it by 100. The change is reflected in the following line:
> 
> ```python
> rtn=float(item["sunikrt"]) / 100,
> ```
> 
> ## How to test
> To test this change, you can use the `positions` method to retrieve portfolio data. The `rtn` value should now be returned as a float, divided by 100. 
> 
> ## Why make this change
> The `rtn` value represents the return on investment. It is more appropriate to represent this value as a float rather than a string, as it is a numerical value. Additionally, dividing the value by 100 converts the return rate from a percentage to a decimal, which is a more standard representation. This change will make the data more accurate and easier to work with in subsequent calculations or data analysis.
</details>