### PR TITLE
🩹 Change color style for positive returns

### DIFF
--- a/pyrb/controllers/cli/main.py
+++ b/pyrb/controllers/cli/main.py
@@ -226,7 +226,7 @@ def _print_portfolio_table(context: RebalanceContext) -> None:
         elif position.rtn == 0:
             rtn_style = "black"
         else:
-            rtn_style = "green"
+            rtn_style = "blue"
 
         table.add_row(
             position.symbol,


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request changes the color of the return style from green to blue in the `_print_portfolio_table` function in the `main.py` file.
> 
> ## What changed
> In the `main.py` file, the color of the return style was previously set to green. This pull request changes the color to blue. The change is made in the `_print_portfolio_table` function.
> 
> ```diff
> -            rtn_style = "green"
> +            rtn_style = "blue"
> ```
> 
> ## How to test
> To test this change, you can run the `_print_portfolio_table` function and observe the color of the return style. It should now be blue instead of green.
> 
> ## Why make this change
> This change is made to improve the readability and user experience of the portfolio table. The color blue is often associated with trust and reliability, which can enhance the user's perception of the portfolio's performance.
</details>