### PR TITLE
🐛 fix cash_balance fetching

### DIFF
--- a/pyrb/repositories/brokerages/ebest/portfolio.py
+++ b/pyrb/repositories/brokerages/ebest/portfolio.py
@@ -18,7 +18,7 @@ class EbestPortfolio(Portfolio):
 
     @property
     def cash_balance(self) -> NonNegativeFloat:
-        return self._serialized_portfolio["t0424OutBlock"]["sunamt1"]
+        return self._serialized_portfolio["CSPAQ12200OutBlock2"]["D2Dps"]
 
     @property
     def positions(self) -> list[Position]:
@@ -51,8 +51,13 @@ class EbestPortfolio(Portfolio):
         self._serialized_portfolio = self._fetch_portfolio()
 
     def _fetch_portfolio(self) -> dict[str, Any]:
-        """주식잔고2 TR을 조회합니다.
+        asset_balance = self._fetch_assets_balance()
+        cash_balance = self._fetch_cash_balance()
+        print(asset_balance | cash_balance)
+        return asset_balance | cash_balance
 
+    def _fetch_assets_balance(self) -> dict[str, Any]:
+        """주식잔고2 TR(t0424)을 조회합니다.
         see: https://openapi.ebestsec.co.kr/apiservice?group_id=73142d9f-1983-48d2-8543-89b75535d34c&api_id=37d22d4d-83cd-40a4-a375-81b010a4a627
         """
         path = "stock/accno"
@@ -66,6 +71,24 @@ class EbestPortfolio(Portfolio):
                 "dangb": "",
                 "charge": "",
                 "cts_expcode": "",
+            }
+        }
+
+        response = self._api_client.send_request("POST", path, headers=headers, json=body)
+        return response.json()
+
+    def _fetch_cash_balance(self) -> dict[str, Any]:
+        """현물계좌예수금 주문가능금액 총평가 조회 TR(CSPAQ12200)을 조회합니다.
+        see: https://openapi.ebestsec.co.kr/apiservice?group_id=73142d9f-1983-48d2-8543-89b75535d34c&api_id=37d22d4d-83cd-40a4-a375-81b010a4a627
+        """
+        path = "stock/accno"
+        content_type = "application/json; charset=UTF-8"
+
+        headers = {"content-type": content_type, "tr_cd": "CSPAQ12200", "tr_cont": "N"}
+
+        body = {
+            "CSPAQ12200InBlock1": {
+                "BalCreTp": "0",
             }
         }
 


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request modifies the `portfolio.py` file in the `ebest` brokerage repository to fetch both asset balance and cash balance separately and return them together. 
> 
> ## What changed
> The `cash_balance` property now fetches data from the `CSPAQ12200OutBlock2` dictionary instead of `t0424OutBlock`. Two new methods, `_fetch_assets_balance` and `_fetch_cash_balance`, have been added to fetch asset balance and cash balance separately. The `refresh` method has been updated to call these two new methods and return their combined result.
> 
> ## How to test
> To test these changes, you can create a portfolio object and call the `refresh` method. Then, check the `cash_balance` property and `positions` property to ensure they are returning the correct values. 
> 
> ## Why make this change
> This change was made to improve the accuracy of the portfolio data by fetching asset balance and cash balance separately. This will provide a more accurate representation of the portfolio's total value.
</details>