### PR TITLE
🧑‍💻 linting 위반사항 수정

### DIFF
--- a/pyrb/controllers/api/main.py
+++ b/pyrb/controllers/api/main.py
@@ -16,7 +16,7 @@ class AccountResponse(BaseModel):
 async def get_default_account(account_service: AccountServiceDep) -> AccountResponse:
     try:
         account = account_service.get()
-    except InitializationError:
-        raise HTTPException(status_code=404, detail="No accounts registered")
+    except InitializationError as e:
+        raise HTTPException(status_code=404, detail="No accounts registered") from e
 
     return AccountResponse(account=account)

--- a/pyrb/repositories/brokerages/base/fetcher.py
+++ b/pyrb/repositories/brokerages/base/fetcher.py
@@ -6,8 +6,6 @@ from pyrb.models.price import CurrentPrice
 
 
 class PriceFetcher(abc.ABC):
-    def __init__(self) -> None: ...
-
     @abc.abstractmethod
     def get_current_price(self, symbol: str) -> CurrentPrice:
         """특정 종목의 현재가를 조회합니다.

--- a/pyrb/repositories/brokerages/base/order_manager.py
+++ b/pyrb/repositories/brokerages/base/order_manager.py
@@ -4,8 +4,6 @@ from pyrb.models.order import Order
 
 
 class OrderManager(abc.ABC):
-    def __init__(self) -> None: ...
-
     @abc.abstractmethod
     def place_order(self, order: Order) -> None:
         """

--- a/pyrb/repositories/brokerages/base/portfolio.py
+++ b/pyrb/repositories/brokerages/base/portfolio.py
@@ -6,8 +6,6 @@ from pyrb.models.position import Position
 
 
 class Portfolio(abc.ABC):
-    def __init__(self) -> None: ...
-
     @property
     @abc.abstractmethod
     def total_value(self) -> NonNegativeFloat:

--- a/pyrb/repositories/brokerages/ebest/client.py
+++ b/pyrb/repositories/brokerages/ebest/client.py
@@ -57,9 +57,9 @@ class EbestAPIClient(BrokerageAPIClient):
     def _raise_for_status(self, response: Response) -> None:
         try:
             response.raise_for_status()
-        except requests.HTTPError:
+        except requests.HTTPError as e:
             # error_code = response.json()["rsp_cd"]
             # error_msg = response.json()["rsp_msg"]
             status_code = response.status_code
             print(response)
-            raise Exception(f"API client error: {status_code}, {response}")
+            raise Exception(f"API client error: {status_code}, {response}") from e

--- a/pyrb/repositories/brokerages/ebest/order_manager.py
+++ b/pyrb/repositories/brokerages/ebest/order_manager.py
@@ -45,4 +45,4 @@ class EbestOrderManager(OrderManager):
             if resp.get("rsp_cd") != "00040":
                 raise OrderPlacementError(resp)
         except HTTPError as e:
-            raise OrderPlacementError(e)
+            raise OrderPlacementError(e) from e


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request improves error handling by chaining exceptions to provide more context when an error occurs. It also removes unnecessary `__init__` methods from abstract base classes.
> 
> ## What changed
> 1. In `pyrb/controllers/api/main.py`, the `get_default_account` function now raises an `HTTPException` with the original `InitializationError` attached for context.
> 2. In `pyrb/repositories/brokerages/base/fetcher.py`, `pyrb/repositories/brokerages/base/order_manager.py`, and `pyrb/repositories/brokerages/base/portfolio.py`, the unnecessary `__init__` methods were removed from the abstract base classes.
> 3. In `pyrb/repositories/brokerages/ebest/client.py`, the `_raise_for_status` method now raises an `Exception` with the original `HTTPError` attached for context.
> 4. In `pyrb/repositories/brokerages/ebest/order_manager.py`, the `place_order` method now raises an `OrderPlacementError` with the original `HTTPError` attached for context.
> 
> ## How to test
> 1. Run the application and make a request to the `get_default_account` endpoint. If an `InitializationError` occurs, the response should now include the original error message.
> 2. Test the abstract base classes to ensure they still function correctly without the `__init__` methods.
> 3. Make a request that triggers an `HTTPError` in the `pyrb/repositories/brokerages/ebest/client.py` file. The error message should now include the original error message.
> 4. Make a request that triggers an `HTTPError` in the `pyrb/repositories/brokerages/ebest/order_manager.py` file. The error message should now include the original error message.
> 
> ## Why make this change
> Chaining exceptions provides more context when an error occurs, which can help with debugging. Removing unnecessary `__init__` methods from abstract base classes makes the code cleaner and easier to read.
</details>