### PR TITLE
✨ 계좌 등록 API 추가

### DIFF
--- a/pyrb/controllers/api/main.py
+++ b/pyrb/controllers/api/main.py
@@ -1,15 +1,29 @@
+from uuid import UUID
+
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
+from starlette.status import HTTP_201_CREATED
 
 from pyrb.controllers.api.deps import AccountServiceDep
+from pyrb.enums import BrokerageType
 from pyrb.exceptions import InitializationError
-from pyrb.models.account import Account
+from pyrb.models.account import Account, AccountFactory
 
 app = FastAPI()
 
 
 class AccountResponse(BaseModel):
     account: Account
+
+
+class AccountCreateRequest(BaseModel):
+    brokerage: BrokerageType
+    app_key: str
+    secret_key: str
+
+
+class AccountCreateResponse(BaseModel):
+    account_id: UUID
 
 
 @app.get("/accounts/default", response_model=AccountResponse)
@@ -20,3 +34,15 @@ async def get_default_account(account_service: AccountServiceDep) -> AccountResp
         raise HTTPException(status_code=404, detail="No accounts registered") from e
 
     return AccountResponse(account=account)
+
+
+@app.post("/accounts", response_model=AccountCreateResponse, status_code=HTTP_201_CREATED)
+async def create_account(
+    account_service: AccountServiceDep, body: AccountCreateRequest
+) -> AccountCreateResponse:
+    account = AccountFactory.create(
+        brokerage=body.brokerage, app_key=body.app_key, app_secret=body.secret_key
+    )
+    account_service.set(account)
+
+    return AccountCreateResponse(account_id=account.id)

--- a/pyrb/models/account.py
+++ b/pyrb/models/account.py
@@ -1,3 +1,4 @@
+import uuid
 from abc import ABC
 from typing import Annotated, Any
 
@@ -9,6 +10,7 @@ from pyrb.enums import BrokerageType
 
 class Account(BaseModel, ABC):
     brokerage: Annotated[BrokerageType, Field(...)]
+    id: uuid.UUID = Field(default_factory=uuid.uuid4)
 
     def to_toml(self) -> str:
         model_dict = self.model_dump()


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces the ability to create new accounts via the API. It includes the addition of new request and response models for account creation, as well as the necessary changes to the account service and account model.
> 
> ## What changed
> - Added `AccountCreateRequest` and `AccountCreateResponse` models to handle account creation requests and responses.
> - Added a new POST endpoint `/accounts` to create a new account.
> - Added an `id` field to the `Account` model, which is automatically generated using `uuid.uuid4`.
> 
> ## How to test
> 1. Pull the changes from this branch into your local environment.
> 2. Run the application.
> 3. Use a tool like curl or Postman to send a POST request to `/accounts` with the necessary data (brokerage, app_key, secret_key).
> 4. Verify that the response includes the newly created account's ID and that the account is correctly created.
> 
> ## Why make this change
> This change allows users to create new accounts via the API, which is a necessary feature for any trading application. It also introduces a unique ID for each account, which can be used to identify and manage accounts.
</details>