### PR TITLE
🐛 model dump시 json mode 적용

### DIFF
--- a/pyrb/models/account.py
+++ b/pyrb/models/account.py
@@ -13,8 +13,7 @@ class Account(BaseModel, ABC):
     id: uuid.UUID = Field(default_factory=uuid.uuid4)
 
     def to_toml(self) -> str:
-        model_dict = self.model_dump()
-        model_dict.update({"brokerage": self.brokerage.value})
+        model_dict = self.model_dump(mode="json")
         return toml.dumps(model_dict)
 
 


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request modifies the `to_toml` method in the `Account` class of the `account.py` file. The method now uses the `model_dump` function with the "json" mode.
> 
> ## What changed
> The `to_toml` method in the `Account` class was previously using the `model_dump` function without any arguments and then updating the `model_dict` with the `brokerage` value. This has been changed to use the `model_dump` function with the "json" mode directly.
> 
> ```diff
> -        model_dict = self.model_dump()
> -        model_dict.update({"brokerage": self.brokerage.value})
> +        model_dict = self.model_dump(mode="json")
> ```
> 
> ## How to test
> To test this change, you can create an instance of the `Account` class and call the `to_toml` method. Ensure that the output is as expected and that the `brokerage` value is included in the output.
> 
> ## Why make this change
> This change simplifies the `to_toml` method by removing an unnecessary update to the `model_dict`. By using the "json" mode in the `model_dump` function, we can ensure that all necessary values, including `brokerage`, are included in the output. This makes the code cleaner and more efficient.
</details>