### PR TITLE
➕ add httpx dev dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -254,6 +254,27 @@ files = [
 ]
 
 [[package]]
+name = "httpcore"
+version = "1.0.4"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "httpcore-1.0.4-py3-none-any.whl", hash = "sha256:ac418c1db41bade2ad53ae2f3834a3a0f5ae76b56cf5aa497d2d033384fc7d73"},
+    {file = "httpcore-1.0.4.tar.gz", hash = "sha256:cb2839ccfcba0d2d3c1131d3c3e26dfc327326fbe7a5dc0dbfe9f6c9151bb022"},
+]
+
+[package.dependencies]
+certifi = "*"
+h11 = ">=0.13,<0.15"
+
+[package.extras]
+asyncio = ["anyio (>=4.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<0.25.0)"]
+
+[[package]]
 name = "httptools"
 version = "0.6.1"
 description = "A collection of framework independent HTTP protocol utils."
@@ -300,6 +321,30 @@ files = [
 
 [package.extras]
 test = ["Cython (>=0.29.24,<0.30.0)"]
+
+[[package]]
+name = "httpx"
+version = "0.27.0"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "httpx-0.27.0-py3-none-any.whl", hash = "sha256:71d5465162c13681bff01ad59b2cc68dd838ea1f10e51574bac27103f00c91a5"},
+    {file = "httpx-0.27.0.tar.gz", hash = "sha256:a0cb88a46f32dc874e04ee956e4c2764aba2aa228f650b06788ba6bda2962ab5"},
+]
+
+[package.dependencies]
+anyio = "*"
+certifi = "*"
+httpcore = "==1.*"
+idna = "*"
+sniffio = "*"
+
+[package.extras]
+brotli = ["brotli", "brotlicffi"]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
 
 [[package]]
 name = "identify"
@@ -1263,4 +1308,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "080f2ec6629bfc3b17a45d763bb5d9cf14a1990307c4c3d307b1ee171de0da06"
+content-hash = "b9a485de64d637d275a09b9d2a828b2edee2547b66ae4b1f3ff13f6dc3cc012d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ pytest-mock = "^3.11.1"
 types-requests = "^2.31.0.2"
 types-pyyaml = "^6.0.12.12"
 types-toml = "^0.10.8.7"
+httpx = "^0.27.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> # Pull Request Description
> 
> ## TL;DR
> This pull request introduces the `httpx` package to the project and updates the `poetry.lock` file accordingly.
> 
> ## What changed
> The `httpx` package was added to the `pyproject.toml` file, and the `poetry.lock` file was updated to include the new package and its dependencies. The `httpx` package is a next-generation HTTP client for Python, and it's compatible with Python versions 3.8 and above.
> 
> The `httpcore` package was also added as a dependency of `httpx`. This package is a minimal low-level HTTP client.
> 
> ## How to test
> To test these changes, you can follow these steps:
> 
> 1. Pull the changes from this branch into your local environment.
> 2. Run `poetry install` to install the new dependencies.
> 3. Use the `httpx` package in your code and verify that it works as expected.
> 
> ## Why make this change
> The `httpx` package was added to support HTTP requests in the project. This package provides features such as request and response handling, content decoding, and connection pooling, which can simplify and improve the HTTP handling in the project.
</details>