### PR TITLE
♻️ 공통 fixture 분리

### DIFF
--- a/tests/services/test_account.py
+++ b/tests/services/test_account.py
@@ -1,28 +1,10 @@
-import tempfile
-from collections.abc import Generator
-from pathlib import Path
-
 import pytest
 from pytest_mock import MockerFixture
 
 from pyrb.enums import BrokerageType
 from pyrb.exceptions import InitializationError
 from pyrb.models.account import Account, AccountFactory
-from pyrb.repositories.account import LocalConfigAccountRepository
 from pyrb.services.account import AccountService
-
-
-@pytest.fixture
-def tmp_config_path() -> Generator[Path, None, None]:
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        config_path = Path(tmpdirname) / "accounts"
-        yield config_path
-
-
-@pytest.fixture
-def account_service(tmp_config_path: Path) -> AccountService:
-    account_repo = LocalConfigAccountRepository(tmp_config_path)
-    return AccountService(account_repo)
 
 
 def test_sut_get_account_with_local_config_account_repository(


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request refactors the test setup for the `AccountService` in the `pyrb` package. It moves the creation of a temporary account repository into a pytest fixture in `conftest.py` and removes redundant code from `test_account.py`.
> 
> ## What changed
> - Added imports for `tempfile`, `Generator`, `Path`, `AccountRepository`, `LocalConfigAccountRepository`, and `AccountService` to `conftest.py`.
> - Created a new pytest fixture `tmp_account_repo` in `conftest.py` that creates a temporary directory and initializes a `LocalConfigAccountRepository` with a config path in that directory.
> - Created another pytest fixture `account_service` in `conftest.py` that initializes an `AccountService` with the `tmp_account_repo` fixture.
> - Removed the imports for `tempfile`, `Generator`, `Path`, and `LocalConfigAccountRepository` from `test_account.py` as they are no longer needed.
> - Removed the pytest fixtures `tmp_config_path` and `account_service` from `test_account.py` as they have been moved to `conftest.py`.
> 
> ## How to test
> To test these changes, run the test suite with `pytest`. All tests should pass as before, indicating that the refactoring has not introduced any regressions.
> 
> ## Why make this change
> This change improves the organization of the test code by moving the setup of the `AccountService` into a central location (`conftest.py`). This makes the tests in `test_account.py` easier to read and understand, as they no longer include setup code that is not directly related to what is being tested. It also allows the `AccountService` setup to be reused in other tests if needed.
</details>