### PR TITLE
♻️ use static method for factor class

### DIFF
--- a/pyrb/controllers/cli/main.py
+++ b/pyrb/controllers/cli/main.py
@@ -95,7 +95,7 @@ def asset_allocate(
     """
     context = _create_context()
 
-    strategy = AssetAllocationStrategyFactory().create(strategy)
+    strategy = AssetAllocationStrategyFactory.create(strategy)
     rebalancer = Rebalancer(context, strategy)
 
     orders = rebalancer.prepare_orders(investment_amount=investment_amount)

--- a/pyrb/services/strategy/asset_allocate.py
+++ b/pyrb/services/strategy/asset_allocate.py
@@ -24,7 +24,8 @@ class AllWeatherKRStrategy(AssetAllocationStrategy):
 
 
 class AssetAllocationStrategyFactory:
-    def create(self, strategy_type: AssetAllocationStrategyEnum) -> AssetAllocationStrategy:
+    @staticmethod
+    def create(strategy_type: AssetAllocationStrategyEnum) -> AssetAllocationStrategy:
         if strategy_type == AssetAllocationStrategyEnum.ALL_WEATHER_KR:
             return AllWeatherKRStrategy()
         else:


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request modifies the `AssetAllocationStrategyFactory` class to use a static method for creating strategies. It also updates the `asset_allocate` function in `main.py` to use this static method.
> 
> ## What changed
> Two files were modified in this pull request:
> 
> 1. `pyrb/controllers/cli/main.py`: The `asset_allocate` function was updated to use the static `create` method from `AssetAllocationStrategyFactory`.
> 
> 2. `pyrb/services/strategy/asset_allocate.py`: The `create` method in `AssetAllocationStrategyFactory` was changed to a static method.
> 
> ## How to test
> To test these changes, follow these steps:
> 
> 1. Pull the changes from this branch into your local environment.
> 2. Run the `asset_allocate` function with a valid strategy type.
> 3. Verify that the function correctly creates and uses the specified strategy.
> 
> ## Why make this change
> The `create` method in `AssetAllocationStrategyFactory` does not rely on any instance variables and is therefore a good candidate for a static method. This change improves the readability and efficiency of the code. It also makes it easier to use the `AssetAllocationStrategyFactory` to create strategies elsewhere in the codebase.
</details>