### PR TITLE
✨ add rebalance api

### DIFF
--- a/pyrb/controllers/api/deps.py
+++ b/pyrb/controllers/api/deps.py
@@ -4,6 +4,7 @@ from fastapi import Depends
 
 from pyrb.controllers.constants import ACCOUNTS_CONFIG_PATH
 from pyrb.repositories.account import AccountRepository, LocalConfigAccountRepository
+from pyrb.repositories.brokerages.context import RebalanceContext, create_rebalance_context
 from pyrb.services.account import AccountService
 
 
@@ -19,3 +20,11 @@ def account_service_dep(account_repo: AccountRepoDep) -> AccountService:
 
 
 AccountServiceDep = Annotated[AccountService, Depends(account_service_dep)]
+
+
+def context_dep(account_repo: AccountRepoDep) -> RebalanceContext:
+    account = account_repo.get()
+    return create_rebalance_context(account)
+
+
+RebalanceContextDep = Annotated[RebalanceContext, Depends(context_dep)]


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces a new rebalance feature to the application. It includes changes to the API endpoints, the addition of new dependencies, and updates to the test suite to cover the new functionality.
> 
> ## What changed
> - Added a new dependency `RebalanceContextDep` in `pyrb/controllers/api/deps.py` to create a rebalance context.
> - Updated `pyrb/controllers/api/main.py` to include new API endpoint for rebalancing strategy. This endpoint accepts a strategy type and an investment amount, and returns the rebalance result.
> - Updated `pyrb/controllers/api/main.py` to include new models `RebalanceRequest` and `RebalanceResponse`.
> - Updated `tests/controllers/test_api.py` to include a new test case for the rebalance feature.
> 
> ## How to test
> - Run the updated test suite with the command `pytest tests/controllers/test_api.py`.
> - Manually test the new API endpoint by sending a POST request to `/strategies/{strategy_type}/rebalance` with a valid strategy type and an investment amount.
> 
> ## Why make this change
> This change is necessary to provide users with the ability to rebalance their portfolio based on a chosen strategy and investment amount. This is a key feature for any portfolio management application.
</details>