### PR TITLE
👷 Add uvicorn server setup for executable building

### DIFF
--- a/pyrb/controllers/api/main.py
+++ b/pyrb/controllers/api/main.py
@@ -77,3 +77,9 @@ async def rebalance(
         rebalanced_at=datetime.datetime.now(ZoneInfo("Asia/Seoul")),
         placed_orders=placed_orders,
     )
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request adds a main execution block to the `main.py` file in the `pyrb/controllers/api` directory. This allows the application to be run directly from the command line using the Uvicorn ASGI server.
> 
> ## What changed
> A new block of code was added to the end of the `main.py` file. This code checks if the file is being run directly (i.e., it is the main module), and if so, it starts the Uvicorn server with the application on host `0.0.0.0` and port `8000`.
> 
> ```python
> if __name__ == "__main__":
>     import uvicorn
> 
>     uvicorn.run(app, host="0.0.0.0", port=8000)
> ```
> 
> ## How to test
> To test this change, navigate to the directory containing the `main.py` file and run the command `python main.py`. You should see the Uvicorn server start up and the application should be accessible at `http://0.0.0.0:8000`.
> 
> ## Why make this change
> This change makes it easier to run the application for development and testing purposes. Instead of having to manually start the Uvicorn server and specify the application, host, and port, you can now simply run the `main.py` file.
</details>