### PR TITLE
🔐 add cors middleware

### DIFF
--- a/pyrb/controllers/api/main.py
+++ b/pyrb/controllers/api/main.py
@@ -3,6 +3,7 @@ from uuid import UUID
 from zoneinfo import ZoneInfo
 
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import AwareDatetime, BaseModel
 from starlette.status import HTTP_201_CREATED
 
@@ -15,6 +16,17 @@ from pyrb.services.rebalance import Rebalancer
 from pyrb.services.strategy.asset_allocate import AssetAllocationStrategyFactory
 
 app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[
+        "http://localhost",
+        "http://localhost:1420",  # tauri
+    ],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 class AccountResponse(BaseModel):

--- a/pyrb/controllers/api/main.py
+++ b/pyrb/controllers/api/main.py
@@ -19,14 +19,16 @@ app = FastAPI()
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost",
-        "http://localhost:1420",  # tauri
-    ],
+    allow_origins=["*"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.get("/ping")
+async def ping() -> str:
+    return "pong"
 
 
 class AccountResponse(BaseModel):

--- a/scripts/build-executable.sh
+++ b/scripts/build-executable.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+pyinstaller -c -F --clean --name run-server-x86_64-unknown-linux-gnu pyrb/controllers/api/main.py


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces Cross-Origin Resource Sharing (CORS) middleware to the FastAPI application and adds a new ping endpoint. It also includes a new script for building an executable.
> 
> ## What changed
> - Added CORS middleware to the FastAPI application in `pyrb/controllers/api/main.py`. This allows the server to accept requests from any origin, with any method and headers.
> - Added a new `/ping` endpoint to the FastAPI application in `pyrb/controllers/api/main.py`. This endpoint simply returns the string "pong".
> - Added a new script `scripts/build-executable.sh` for building an executable. This script uses PyInstaller to compile the FastAPI application into a standalone executable.
> 
> ## How to test
> - To test the CORS middleware, try making a request to the server from a different origin. The server should accept the request and respond appropriately.
> - To test the new `/ping` endpoint, make a GET request to `/ping`. The server should respond with the string "pong".
> - To test the new build script, run `./scripts/build-executable.sh`. This should create a new executable in the current directory.
> 
> ## Why make this change
> - The CORS middleware is necessary for the server to accept requests from different origins. This is especially important for web applications, which often need to make requests to servers on different domains.
> - The `/ping` endpoint is a simple health check that can be used to verify that the server is running and responding to requests.
> - The build script makes it easy to compile the FastAPI application into a standalone executable, which can be useful for deployment or distribution.
</details>