### PR TITLE
✨ Add portfolio endpoint to retrieve account portfolio

### DIFF
--- a/pyrb/controllers/api/main.py
+++ b/pyrb/controllers/api/main.py
@@ -12,6 +12,7 @@ from pyrb.enums import AssetAllocationStrategyEnum, BrokerageType
 from pyrb.exceptions import InitializationError
 from pyrb.models.account import Account, AccountFactory
 from pyrb.models.order import OrderPlacementResult
+from pyrb.models.position import Position
 from pyrb.services.rebalance import Rebalancer
 from pyrb.services.strategy.asset_allocate import AssetAllocationStrategyFactory
 
@@ -45,6 +46,12 @@ class AccountCreateResponse(BaseModel):
     account_id: UUID
 
 
+class PortfolioResponse(BaseModel):
+    total_value: float
+    cash_balance: float
+    positions: list[Position]
+
+
 class RebalanceRequest(BaseModel):
     investment_amount: float | None
 
@@ -74,6 +81,17 @@ async def create_account(
     account_service.set(account)
 
     return AccountCreateResponse(account_id=account.id)
+
+
+@app.get("/portfolio", response_model=PortfolioResponse)
+async def get_portfolio(context: RebalanceContextDep) -> PortfolioResponse:
+    portfolio = context.portfolio
+
+    return PortfolioResponse(
+        total_value=portfolio.total_value,
+        cash_balance=portfolio.cash_balance,
+        positions=portfolio.positions,
+    )
 
 
 # TODO: Swagger에서 StrEnum이 제대로 표시되지 않는 문제 원인 파악 후 수정


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request adds error handling for when the account is not set in the context, and introduces a new endpoint to retrieve portfolio information.
> 
> ## What changed
> - Added `HTTPException` import in `deps.py` for error handling.
> - Modified `context_dep` function in `deps.py` to handle `InitializationError` and raise a `404` HTTPException.
> - Added a new `PortfolioResponse` model in `main.py` to represent portfolio information.
> - Added a new `/portfolio` endpoint in `main.py` to retrieve portfolio information.
> - Added tests for the new `/portfolio` endpoint in `test_api.py`.
> 
> ## How to test
> 1. Run the tests in `test_api.py`.
> 2. Use a client to make a `GET` request to the `/portfolio` endpoint and verify the response.
> 
> ## Why make this change
> - This change improves the error handling when the account is not set in the context by raising a `404` HTTPException.
> - The addition of the `/portfolio` endpoint allows users to retrieve detailed portfolio information, enhancing the functionality of the API.
</details>