### PR TITLE
♻️ Refactor Rebalancer class to accept strategy parameter

### DIFF
--- a/pyrb/controllers/cli/main.py
+++ b/pyrb/controllers/cli/main.py
@@ -43,9 +43,9 @@ def holding_portfolio(
     context = _create_context()
 
     strategy = HoldingPortfolioRebalanceStrategy(context)
-    rebalancer = Rebalancer(context, strategy)
+    rebalancer = Rebalancer(context)
 
-    orders = rebalancer.prepare_orders(investment_amount=investment_amount)
+    orders = rebalancer.prepare_orders(strategy=strategy, investment_amount=investment_amount)
     _place_orders(context, rebalancer, orders)
 
 
@@ -78,9 +78,9 @@ def explicit_target(
 
     targets = read_targets_from_source(targets_source)
     strategy = ExplicitTargetRebalanceStrategy(targets)
-    rebalancer = Rebalancer(context, strategy)
+    rebalancer = Rebalancer(context)
 
-    orders = rebalancer.prepare_orders(investment_amount=investment_amount)
+    orders = rebalancer.prepare_orders(strategy=strategy, investment_amount=investment_amount)
     _place_orders(context, rebalancer, orders)
 
 
@@ -96,9 +96,9 @@ def asset_allocate(
     context = _create_context()
 
     strategy = AssetAllocationStrategyFactory.create(strategy)
-    rebalancer = Rebalancer(context, strategy)
+    rebalancer = Rebalancer(context)
 
-    orders = rebalancer.prepare_orders(investment_amount=investment_amount)
+    orders = rebalancer.prepare_orders(strategy=strategy, investment_amount=investment_amount)
     _place_orders(context, rebalancer, orders)
 
 

--- a/pyrb/services/rebalance.py
+++ b/pyrb/services/rebalance.py
@@ -13,11 +13,10 @@ from pyrb.services.strategy.base import Strategy
 
 
 class Rebalancer:
-    def __init__(self, context: RebalanceContext, strategy: Strategy) -> None:
+    def __init__(self, context: RebalanceContext) -> None:
         self._context = context
-        self._strategy = strategy
 
-    def prepare_orders(self, investment_amount: float) -> list[Order]:
+    def prepare_orders(self, strategy: Strategy, investment_amount: float) -> list[Order]:
         """
         Prepare a list of orders to rebalance the portfolio based on the given investment amount.
         If the investment amount is greater than the total value of the portfolio, an exception
@@ -51,7 +50,7 @@ class Rebalancer:
 
         self._validate_investment_amount(investment_amount)
 
-        weight_by_stock = self._strategy.create_target_weights()
+        weight_by_stock = strategy.create_target_weights()
 
         current_prices = _fetch_current_prices(self._context, weight_by_stock)
         orders: list[Order] = []


### PR DESCRIPTION


---

<details open><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request refactors the `Rebalancer` class and its usage in `main.py` to improve flexibility. The `strategy` parameter is moved from the `Rebalancer` constructor to the `prepare_orders` method, allowing different strategies to be used with the same `Rebalancer` instance.
> 
> ## What changed
> - In `rebalance.py`, the `Rebalancer` class no longer takes a `strategy` parameter in its constructor. Instead, the `strategy` is passed as a parameter to the `prepare_orders` method.
> - In `main.py`, the `strategy` is no longer passed to the `Rebalancer` constructor. Instead, it is passed to the `prepare_orders` method.
> 
> ## How to test
> 1. Run the existing unit tests to ensure that the refactoring has not broken any existing functionality.
> 2. Create a `Rebalancer` instance without passing a `strategy` to the constructor.
> 3. Call the `prepare_orders` method on the `Rebalancer` instance, passing in a `strategy` and an `investment_amount`.
> 4. Verify that the method returns the expected orders.
> 
> ## Why make this change
> This change improves the flexibility of the `Rebalancer` class. Previously, a `Rebalancer` instance was tied to a specific strategy, which was specified at the time of creation. With this change, the same `Rebalancer` instance can be used with different strategies, which can be specified at the time of preparing orders. This makes the `Rebalancer` class more versatile and easier to use in different contexts.
</details>