### PR TITLE
✨ Add profit field to Position model and Portfolio class

### DIFF
--- a/pyrb/models/position.py
+++ b/pyrb/models/position.py
@@ -30,3 +30,4 @@ class Position(BaseModel):
     average_buy_price: PositiveFloat  # 매입단가
     total_amount: PositiveFloat  # 평가금액
     rtn: float  # 수익률
+    profit: float  # 수익금

--- a/pyrb/repositories/brokerages/ebest/portfolio.py
+++ b/pyrb/repositories/brokerages/ebest/portfolio.py
@@ -30,6 +30,7 @@ class EbestPortfolio(Portfolio):
                 average_buy_price=item["pamt"],
                 total_amount=item["appamt"],
                 rtn=float(item["sunikrt"]) / 100,
+                profit=item["dtsunik"],
             )
             for item in self._serialized_portfolio["t0424OutBlock1"]
         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ class FakePortfolio(Portfolio):
                 average_buy_price=100,
                 total_amount=10000,
                 rtn=0.0,
+                profit=0.0,
             ),
             Position(
                 asset=Asset(symbol="005930", label="삼성전자"),
@@ -44,6 +45,7 @@ class FakePortfolio(Portfolio):
                 average_buy_price=150,
                 total_amount=7500,
                 rtn=0.0,
+                profit=0.0,
             ),
         ]
 

--- a/tests/controllers/test_api.py
+++ b/tests/controllers/test_api.py
@@ -240,6 +240,7 @@ def test_get_portfolio(fake_rebalance_context: RebalanceContext) -> None:
                 "average_buy_price": 100,
                 "total_amount": 10000,
                 "rtn": 0.0,
+                "profit": 0,
             },
             {
                 "asset": {"symbol": "005930", "label": "삼성전자", "asset_class": "STOCK"},
@@ -248,6 +249,7 @@ def test_get_portfolio(fake_rebalance_context: RebalanceContext) -> None:
                 "average_buy_price": 150,
                 "total_amount": 7500,
                 "rtn": 0.0,
+                "profit": 0,
             },
         ],
     }


### PR DESCRIPTION
### TL;DR

The current pull request updates the `Position` model by introducing a new field `profit` and modifies unit tests to reflect this change.

### What changed?

A new field `profit` has been introduced in the `Position` model found in 'pyrb/models/position.py'. Corresponding changes are also made in 'pyrb/repositories/brokerages/ebest/portfolio.py' and test files.

### How to test?

Run unit tests to ensure all the changes work as expected.

### Why make this change?

This additional field `profit` can provide more detailed insights about the individual positions held within the portfolio.

---

