### PR TITLE
👷 Add automated frontend release process workflow

### DIFF
--- a/.github/workflows/frontend-release.yaml
+++ b/.github/workflows/frontend-release.yaml
@@ -1,0 +1,49 @@
+name: Automated Frontend Release Process
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "frontend/**"
+
+jobs:
+  create-release-and-publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v5
+
+      - name: Determine Version Change
+        id: version_check
+        run: |
+          VERSION="frontend@v$(node -p "require('./package.json').version")"
+          echo "Current version: $VERSION"
+
+          LATEST_RELEASE=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/releases?per_page=5" | \
+            jq -r '.[] | select(.tag_name | startswith("frontend@v")).tag_name' | head -n 1)
+          echo "Latest release version: $LATEST_RELEASE"
+
+          if [ "$VERSION" != "$LATEST_RELEASE" ]; then
+            echo "Version has changed."
+            echo "version_changed=true" >> $GITHUB_OUTPUT
+            echo "new_version=$VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "No version change detected."
+            echo "version_changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Release
+        if: steps.version_check.outputs.version_changed == 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.version_check.outputs.new_version }}
+          generate_release_notes: True


### PR DESCRIPTION
### TL;DR

This PR adds an automated release process for the frontend code.

### What changed?

A new Github Action workflow file `frontend-release.yaml` has been added. This workflow triggers on a push to the `main` branch with changes in the `frontend/` directory. It compares the current version in `package.json` with the latest release tagged on Github. If the version has changed, it creates a new release.

### How to test?

To test, make a change in the frontend directory that updates the version in `package.json`, then push to `main`. Check the 'Actions' tab on Github to see the workflow run and the 'Releases' tab to see the new release.

### Why make this change?

This change automates the release process, reducing the likelihood of human error and simplifying the release process for new changes.

---

