### PR TITLE
👷 Add backend executable build CI

### DIFF
--- a/.github/workflows/backend-release.yaml
+++ b/.github/workflows/backend-release.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install Poetry
         run: |
-          curl -sSL https://install.python-poetry.org | python3 -
+          curl -sSL https://install.python-poetry.org | python3.11 -
 
       - name: Install dependencies with Poetry
         run: |
@@ -50,6 +50,21 @@ jobs:
             echo "No version change detected."
             echo "version_changed=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Call Reusable Workflow to Build Backend for Linux
+        uses: ./.github/workflows/backend-build.yaml
+        with:
+          platform: linux
+
+      - name: Call Reusable Workflow to Build Backend for macOS
+        uses: ./.github/workflows/backend-build.yaml
+        with:
+          platform: macos
+
+      - name: Call Reusable Workflow to Build Backend for Windows
+        uses: ./.github/workflows/backend-build.yaml
+        with:
+          platform: windows
 
       - name: Create Release
         if: steps.version_check.outputs.version_changed == 'true'

--- a/.github/workflows/build-backend-executable.yaml
+++ b/.github/workflows/build-backend-executable.yaml
@@ -1,0 +1,74 @@
+name: Build Backend Executable
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        description: "Target platform for the build"
+        required: true
+        type: string
+
+jobs:
+  build-backend-linux:
+    runs-on: ubuntu-latest
+    if: ${{ inputs.platform == 'linux' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build executable in Docker
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace \
+            ubuntu:18.04 /bin/bash -c "\
+              apt-get update && \
+              apt-get install -y python3.11 python3.11-venv python3.11-dev && \
+              curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11 && \
+              pip3.11 install pyinstaller && \
+              pyinstaller -c -F --clean --name run-server-x86_64-unknown-linux-gnu backend/pyrb/controllers/api/main.py && \
+              cp backend/dist/run-server-x86_64-unknown-linux-gnu frontend/src-tauri/bin/"
+
+  build-backend-macos:
+    runs-on: macos-12
+    if: ${{ inputs.platform == 'macos' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install PyInstaller
+        run: pip install pyinstaller
+
+      - name: Build backend executable
+        run: |
+          pyinstaller -c -F --clean --name run-server-aarch64-apple-darwin backend/pyrb/controllers/api/main.py
+          cp backend/dist/run-server-aarch64-apple-darwin frontend/src-tauri/bin/
+
+  build-backend-windows:
+    runs-on: windows-2019
+    if: ${{ inputs.platform == 'windows' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install PyInstaller
+        run: pip install pyinstaller
+
+      - name: Build backend executable
+        run: |
+          pyinstaller -c -F --clean --name run-server-x86_64-pc-windows-msvc backend/pyrb/controllers/api/main.py
+          cp backend/dist/run-server-x86_64-pc-windows-msvc.exe frontend/src-tauri/bin/


### PR DESCRIPTION
### TL;DR

This PR introduces changes to the GitHub Actions workflows set up in order to support separate backend builds for Linux, macOS, and Windows platforms.

### What changed?

The main change is the creation of a new workflow that builds the backend executables for each platform depending on specified conditions. The old workflow has also been updated to call this new workflow for each platform.

### How to test?

You can test this by checking the build logs under the Checks tab for this PR or by triggering a new workflow run in your local fork.

### Why make this change?

These changes will allow us to ensure that our backend runs consistently across different platforms, taking into account platform-specific settings and dependencies.

---

