### PR TITLE
✏️ fix CI typo

### DIFF
--- a/.github/workflows/backend-release.yaml
+++ b/.github/workflows/backend-release.yaml
@@ -52,17 +52,17 @@ jobs:
           fi
 
       - name: Call Reusable Workflow to Build Backend for Linux
-        uses: ./.github/workflows/backend-build-executable.yaml
+        uses: ./.github/workflows/build-backend-executable.yaml
         with:
           platform: linux
 
       - name: Call Reusable Workflow to Build Backend for macOS
-        uses: ./.github/workflows/backend-build-executable.yaml
+        uses: ./.github/workflows/build-backend-executable.yaml
         with:
           platform: macos
 
       - name: Call Reusable Workflow to Build Backend for Windows
-        uses: ./.github/workflows/backend-build-executable.yaml
+        uses: ./.github/workflows/build-backend-executable.yaml
         with:
           platform: windows
 


### PR DESCRIPTION
### TL;DR

Updated the name of the reusable workflow for building backend executables.

### What changed?

The workflow file `backend-build-executable.yaml` was renamed from `backend-release.yaml` in order to make its purpose more clear.

### How to test?

To test, you need to trigger a backend build that uses the renamed workflow and ensure that it completes successfully without any issues.

### Why make this change?

The motivation behind this change is to increase the readability and clarity of our workflow files, making it easier to understand their purpose at a glance. This contributes to better maintainability and easier troubleshooting.

---

