### PR TITLE
💚 fix CI routes

### DIFF
--- a/.github/workflows/backend-release.yaml
+++ b/.github/workflows/backend-release.yaml
@@ -51,9 +51,6 @@ jobs:
             echo "version_changed=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Checkout repository for reusable workflows
-        uses: actions/checkout@v4
-
       - name: Call Reusable Workflow to Build Backend for Linux
         uses: .github/workflows/build-backend-executable.yaml
         with:

--- a/.github/workflows/backend-release.yaml
+++ b/.github/workflows/backend-release.yaml
@@ -51,18 +51,21 @@ jobs:
             echo "version_changed=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Checkout repository for reusable workflows
+        uses: actions/checkout@v4
+
       - name: Call Reusable Workflow to Build Backend for Linux
-        uses: ./.github/workflows/build-backend-executable.yaml
+        uses: .github/workflows/build-backend-executable.yaml
         with:
           platform: linux
 
       - name: Call Reusable Workflow to Build Backend for macOS
-        uses: ./.github/workflows/build-backend-executable.yaml
+        uses: .github/workflows/build-backend-executable.yaml
         with:
           platform: macos
 
       - name: Call Reusable Workflow to Build Backend for Windows
-        uses: ./.github/workflows/build-backend-executable.yaml
+        uses: .github/workflows/build-backend-executable.yaml
         with:
           platform: windows
 


### PR DESCRIPTION
### TL;DR

This PR updates the paths used in the GitHub CI workflow for building backend executables across multiple platforms (Linux, macOS, Windows).

### What changed?

The paths used to reference the 'build-backend-executable.yaml' workflow file have been changed from relative to absolute.

### How to test?

After this PR is merged, triggering the CI should successfully execute the `build-backend-executable.yaml` workflow with the updated absolute paths.

### Why make this change?

This change ensures that the CI workflow can correctly locate and run the `build-backend-executable.yaml` workflow regardless of the execution context, providing consistency and preventing potential build errors.

---

