### PR TITLE
💚 fix CI

### DIFF
--- a/.github/workflows/backend-release.yaml
+++ b/.github/workflows/backend-release.yaml
@@ -52,17 +52,17 @@ jobs:
           fi
 
       - name: Call Reusable Workflow to Build Backend for Linux
-        uses: .github/workflows/build-backend-executable.yaml
+        uses: ../.github/workflows/build-backend-executable.yaml
         with:
           platform: linux
 
       - name: Call Reusable Workflow to Build Backend for macOS
-        uses: .github/workflows/build-backend-executable.yaml
+        uses: ../.github/workflows/build-backend-executable.yaml
         with:
           platform: macos
 
       - name: Call Reusable Workflow to Build Backend for Windows
-        uses: .github/workflows/build-backend-executable.yaml
+        uses: ../.github/workflows/build-backend-executable.yaml
         with:
           platform: windows
 


### PR DESCRIPTION
### TL;DR

This change is about updating the paths used in the `backend-release.yaml` workflow file to call reusable workflows for building the backend executable on different platforms.

### What changed?

The paths previously pointed to the same directory, but now they point to the parent directory, indicating that the reusable workflows' location might have been changed.

### How to test?

Ensure that the CI/CD pipeline runs correctly without errors related to the path changes applied in this PR. Verify that the backend is being built correctly on all specified platforms.

### Why make this change?

This change ensures that the project's CI/CD workflow uses the correct paths to reusable workflows. This is imperative for the smooth execution of the CI/CD pipeline tasks and the successful build of the backend executable on different platforms.

---

