### PR TITLE
🔖 release version backend@0.10.11

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyrb"
-version = "0.10.10"
+version = "0.10.11"
 description = "Python Rebalancer"
 authors = [{ name = "Minki Kim", email = "mingi3314@gmail.com" }]
 requires-python = ">=3.8, <3.13"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -620,7 +620,7 @@ wheels = [
 
 [[package]]
 name = "pyrb"
-version = "0.10.10"
+version = "0.10.11"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
### TL;DR

Bump PyRB version from 0.10.10 to 0.10.11

### What changed?

Updated the version number of PyRB (Python Rebalancer) from 0.10.10 to 0.10.11 in both `pyproject.toml` and `uv.lock` files.

### How to test?

- Verify that the version number is correctly updated in the package metadata
- Run the application to ensure it works with the new version
- Check that any version-dependent features are functioning correctly

### Why make this change?

This version bump is necessary to reflect recent changes to the codebase and to ensure proper versioning for the next release. Following semantic versioning, this patch increment indicates backward-compatible bug fixes or minor improvements.